### PR TITLE
Remove Automatic Code Coverage Generation

### DIFF
--- a/.github/workflows/build-and-test-xcodebuild.yml
+++ b/.github/workflows/build-and-test-xcodebuild.yml
@@ -49,7 +49,6 @@ jobs:
             -project ${{ inputs.xcodeprojname }} \
             -scheme ${{ inputs.scheme }} \
             -destination 'name=iPhone 14 Pro Max' \
-            -enableCodeCoverage YES \
             -resultBundlePath ${{ inputs.scheme }}.xcresult \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO


### PR DESCRIPTION
# Remove Automatic Code Coverage Generation

## :recycle: Current situation & Problem
- The current code coverage collection is sometimes not generating coverage for mixed SPM and Xcode projects. This PR removes the flag to rely on Xcode projects to enable the collection of code coverage in the Xcode project scheme editor.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

