### PR TITLE
Resolve Dependencies Before Building Project for SPM Xcodebuild

### DIFF
--- a/.github/workflows/build-and-test-xcodebuild-spm.yml
+++ b/.github/workflows/build-and-test-xcodebuild-spm.yml
@@ -40,9 +40,11 @@ jobs:
           swift --version
           echo "inputs.path: ${{ inputs.path }}"
           echo "inputs.scheme: ${{ inputs.scheme }}"
-    - name: Build and Test
+    - name: Resolve Dependencies
       run: |
           xcodebuild -resolvePackageDependencies
+    - name: Build and Test
+      run: |
           xcodebuild test \
             -scheme ${{ inputs.scheme }} \
             -sdk iphonesimulator \

--- a/.github/workflows/build-and-test-xcodebuild-spm.yml
+++ b/.github/workflows/build-and-test-xcodebuild-spm.yml
@@ -43,9 +43,6 @@ jobs:
     - name: Build and Test
       run: |
           xcodebuild -resolvePackageDependencies
-            -scheme ${{ inputs.scheme }} \
-            -sdk iphonesimulator \
-            -destination "name=iPhone 14 Pro Max"
           xcodebuild test \
             -scheme ${{ inputs.scheme }} \
             -sdk iphonesimulator \

--- a/.github/workflows/build-and-test-xcodebuild-spm.yml
+++ b/.github/workflows/build-and-test-xcodebuild-spm.yml
@@ -43,6 +43,7 @@ jobs:
     - name: Build and Test
       run: |
           xcodebuild test \
+            -resolvePackageDependencies
             -scheme ${{ inputs.scheme }} \
             -sdk iphonesimulator \
             -destination "name=iPhone 14 Pro Max" \

--- a/.github/workflows/build-and-test-xcodebuild-spm.yml
+++ b/.github/workflows/build-and-test-xcodebuild-spm.yml
@@ -42,8 +42,11 @@ jobs:
           echo "inputs.scheme: ${{ inputs.scheme }}"
     - name: Build and Test
       run: |
+          xcodebuild -resolvePackageDependencies
+            -scheme ${{ inputs.scheme }} \
+            -sdk iphonesimulator \
+            -destination "name=iPhone 14 Pro Max"
           xcodebuild test \
-            -resolvePackageDependencies
             -scheme ${{ inputs.scheme }} \
             -sdk iphonesimulator \
             -destination "name=iPhone 14 Pro Max" \


### PR DESCRIPTION
# Resolve Dependencies Before Building Project for SPM Xcodebuild

## :recycle: Current situation & Problem
The current xcodebuild SPM workflow fails when we add dependencies to the CardinalKit Swift Package.

## :bulb: Proposed solution
We address this by adding a explicit flag to resolve dependencies beforehand.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

