### PR TITLE
Use xcpretty

### DIFF
--- a/.github/workflows/build-and-test-xcodebuild-spm.yml
+++ b/.github/workflows/build-and-test-xcodebuild-spm.yml
@@ -34,6 +34,8 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Install xcpretty
+      run: gem install xcpretty
     - name: Check Environment
       run: |
           xcodebuild -version
@@ -45,13 +47,15 @@ jobs:
           xcodebuild -resolvePackageDependencies
     - name: Build and Test
       run: |
-          xcodebuild test \
+          set -o pipefail \
+          && xcodebuild test \
             -scheme ${{ inputs.scheme }} \
             -sdk iphonesimulator \
             -destination "name=iPhone 14 Pro Max" \
             -enableCodeCoverage YES \
             -resultBundlePath ${{ inputs.scheme }}.xcresult \
-            CODE_SIGNING_ALLOWED="NO"
+            CODE_SIGNING_ALLOWED="NO" \
+          | xcpretty
     - name: Upload Artifact
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build-and-test-xcodebuild-spm.yml
+++ b/.github/workflows/build-and-test-xcodebuild-spm.yml
@@ -44,7 +44,9 @@ jobs:
           echo "inputs.scheme: ${{ inputs.scheme }}"
     - name: Resolve Dependencies
       run: |
-          xcodebuild -resolvePackageDependencies
+          set -o pipefail \
+          $$ xcodebuild -resolvePackageDependencies \
+          | xcpretty
     - name: Build and Test
       run: |
           set -o pipefail \

--- a/.github/workflows/build-and-test-xcodebuild.yml
+++ b/.github/workflows/build-and-test-xcodebuild.yml
@@ -45,6 +45,11 @@ jobs:
           swift --version
           echo "inputs.xcodeprojname: ${{ inputs.xcodeprojname }}"
           echo "inputs.scheme: ${{ inputs.scheme }}"
+    - name: Resolve Dependencies
+      run: |
+          set -o pipefail \
+          $$ xcodebuild -resolvePackageDependencies \
+          | xcpretty
     - name: Build and Test Example App
       run: |
           set -o pipefail \

--- a/.github/workflows/build-and-test-xcodebuild.yml
+++ b/.github/workflows/build-and-test-xcodebuild.yml
@@ -37,6 +37,8 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Install xcpretty
+      run: gem install xcpretty
     - name: Check Environment
       run: |
           xcodebuild -version
@@ -45,13 +47,15 @@ jobs:
           echo "inputs.scheme: ${{ inputs.scheme }}"
     - name: Build and Test Example App
       run: |
-          xcodebuild test \
+          set -o pipefail \
+          && xcodebuild test \
             -project ${{ inputs.xcodeprojname }} \
             -scheme ${{ inputs.scheme }} \
             -destination 'name=iPhone 14 Pro Max' \
             -resultBundlePath ${{ inputs.scheme }}.xcresult \
             CODE_SIGN_IDENTITY="" \
-            CODE_SIGNING_REQUIRED=NO
+            CODE_SIGNING_REQUIRED=NO \
+          | xcpretty
     - name: Upload Artifact
       if: always()
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
# Use xcpretty

## :recycle: Current situation & Problem
The xcodebuild command outputs are currently hard to read and understand if a build error occurs.

## :bulb: Proposed solution
Using xcpretty provides a better output for the GitHub Action runs.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

