### PR TITLE
Self-Hosted Github Action Runner Detection & Make Caching Configurable 

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -75,15 +75,6 @@ jobs:
           xcodebuild -version
           swift --version
           echo "env.selfhosted: ${{ env.selfhosted }}"
-          echo "inputs.path: ${{ inputs.path }}"
-          echo "inputs.runsonlabels: ${{ inputs.runsonlabels }}"
-          echo "inputs.scheme: ${{ inputs.scheme }}"
-          echo "inputs.fastlanelane: ${{ inputs.fastlanelane }}"
-          echo "inputs.customcommand: ${{ inputs.customcommand }}"
-          echo "inputs.artifactname: ${{ inputs.artifactname }}"
-          echo "inputs.setupsigning: ${{ inputs.setupsigning }}"
-          echo "inputs.cacheDerivedData: ${{ inputs.cacheDerivedData }}"
-          echo "inputs.setupfirebaseemulator: ${{ inputs.setupfirebaseemulator }}"
     - name: Install xcpretty
       if: "!env.selfhosted && inputs.scheme != ''"
       run: gem install xcpretty

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -20,7 +20,7 @@ on:
         description: 'JSON-based collection of labels indicating which type of github runner should be chosen'
         required: false
         type: string
-        default: '["macos-12"]'
+        default: '["macos-latest"]'
       scheme:
         description: 'The scheme in the Xcode project. Either use `scheme` to use xcodebuild, `fastlanelane` to use fastlane, or a custom command using `customcommand`'
         required: false
@@ -67,7 +67,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: maxim-lobanov/setup-xcode@v1
-      if: "!contains(inputs.runsonlabels, 'self-hosted')"
+      if: "!env.action_state"
       with:
         xcode-version: latest-stable
     - name: Check environment
@@ -79,7 +79,7 @@ jobs:
           echo "inputs.scheme: ${{ inputs.scheme }}"
           echo "inputs.setupsigning: ${{ inputs.setupsigning }}"
     - name: Install xcpretty
-      if: "!contains(inputs.runsonlabels, 'self-hosted') && inputs.scheme != ''"
+      if: "!env.action_state && inputs.scheme != ''"
       run: gem install xcpretty
     - name: Cache .derivedData folder
       if: "inputs.cacheDerivedData"
@@ -90,22 +90,22 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-${{ runner.arch }}-derivedData-
     - name: Cache Firebase Emulators
-      if: "!contains(inputs.runsonlabels, 'self-hosted') && inputs.setupfirebaseemulator"
+      if: "!env.action_state && inputs.setupfirebaseemulator"
       uses: actions/cache@v3
       with:
         path: ~/.cache/firebase/emulators
         key: ${{ runner.os }}-${{ runner.arch }}-firebase-emulators-${{ hashFiles('~/.cache/firebase/emulators/**') }}
     - name: Setup NodeJS
-      if: "!contains(inputs.runsonlabels, 'self-hosted') && inputs.setupfirebaseemulator"
+      if: "!env.action_state && inputs.setupfirebaseemulator"
       uses: actions/setup-node@v3
     - name: Setup Java
-      if: "!contains(inputs.runsonlabels, 'self-hosted') && inputs.setupfirebaseemulator"
+      if: "!env.action_state && inputs.setupfirebaseemulator"
       uses: actions/setup-java@v3
       with:
         distribution: 'microsoft'
         java-version: '17'
     - name: Install Firebase CLI Tools
-      if: "!contains(inputs.runsonlabels, 'self-hosted') && inputs.setupfirebaseemulator"
+      if: "!env.action_state && inputs.setupfirebaseemulator"
       run: npm install -g firebase-tools
     - name: Install the Apple certificate and provisioning profile
       if: ${{ inputs.setupsigning }}
@@ -175,7 +175,7 @@ jobs:
         name: ${{ inputs.artifactname }}
         path: ${{ inputs.artifactname }}
     - name: Clean up keychain and provisioning profile
-      if: "(inputs.setupsigning && contains(inputs.runsonlabels, 'self-hosted')) || failure()"
+      if: "(inputs.setupsigning && env.action_state) || failure()"
       run: |
         security delete-keychain $RUNNER_TEMP/app-signing.keychain-db
         rm ~/Library/MobileDevice/Provisioning\ Profiles/build_pp.mobileprovision

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -162,7 +162,7 @@ jobs:
           | xcpretty
     - name: Fastlane
       if: ${{ inputs.fastlanelane != '' }}
-      run: bundler install && bundle exec fastlane ${{ inputs.fastlanelane }}
+      run: fastlane ${{ inputs.fastlanelane }}
       env:
         APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
         APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -67,19 +67,25 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: maxim-lobanov/setup-xcode@v1
-      if: "!env.action_state"
+      if: "!env.selfhosted"
       with:
         xcode-version: latest-stable
     - name: Check environment
       run: |
           xcodebuild -version
           swift --version
+          echo "env.selfhosted: ${{ env.selfhosted }}"
           echo "inputs.path: ${{ inputs.path }}"
           echo "inputs.runsonlabels: ${{ inputs.runsonlabels }}"
           echo "inputs.scheme: ${{ inputs.scheme }}"
+          echo "inputs.fastlanelane: ${{ inputs.fastlanelane }}"
+          echo "inputs.customcommand: ${{ inputs.customcommand }}"
+          echo "inputs.artifactname: ${{ inputs.artifactname }}"
           echo "inputs.setupsigning: ${{ inputs.setupsigning }}"
+          echo "inputs.cacheDerivedData: ${{ inputs.cacheDerivedData }}"
+          echo "inputs.setupfirebaseemulator: ${{ inputs.setupfirebaseemulator }}"
     - name: Install xcpretty
-      if: "!env.action_state && inputs.scheme != ''"
+      if: "!env.selfhosted && inputs.scheme != ''"
       run: gem install xcpretty
     - name: Cache .derivedData folder
       if: "inputs.cacheDerivedData"
@@ -90,22 +96,22 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-${{ runner.arch }}-derivedData-
     - name: Cache Firebase Emulators
-      if: "!env.action_state && inputs.setupfirebaseemulator"
+      if: "!env.selfhosted && inputs.setupfirebaseemulator"
       uses: actions/cache@v3
       with:
         path: ~/.cache/firebase/emulators
         key: ${{ runner.os }}-${{ runner.arch }}-firebase-emulators-${{ hashFiles('~/.cache/firebase/emulators/**') }}
     - name: Setup NodeJS
-      if: "!env.action_state && inputs.setupfirebaseemulator"
+      if: "!env.selfhosted && inputs.setupfirebaseemulator"
       uses: actions/setup-node@v3
     - name: Setup Java
-      if: "!env.action_state && inputs.setupfirebaseemulator"
+      if: "!env.selfhosted && inputs.setupfirebaseemulator"
       uses: actions/setup-java@v3
       with:
         distribution: 'microsoft'
         java-version: '17'
     - name: Install Firebase CLI Tools
-      if: "!env.action_state && inputs.setupfirebaseemulator"
+      if: "!env.selfhosted && inputs.setupfirebaseemulator"
       run: npm install -g firebase-tools
     - name: Install the Apple certificate and provisioning profile
       if: ${{ inputs.setupsigning }}
@@ -175,7 +181,7 @@ jobs:
         name: ${{ inputs.artifactname }}
         path: ${{ inputs.artifactname }}
     - name: Clean up keychain and provisioning profile
-      if: "(inputs.setupsigning && env.action_state) || failure()"
+      if: "(inputs.setupsigning && env.selfhosted) || failure()"
       run: |
         security delete-keychain $RUNNER_TEMP/app-signing.keychain-db
         rm ~/Library/MobileDevice/Provisioning\ Profiles/build_pp.mobileprovision

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -46,6 +46,11 @@ on:
         required: false
         type: boolean
         default: false
+      cacheDerivedData:
+        description: 'Cache the derived data folder for a build using xcodebuild'
+        required: false
+        type: boolean
+        default: false
       setupfirebaseemulator:
         description: 'Setup the Firebase Emulator'
         required: false
@@ -77,6 +82,7 @@ jobs:
       if: "!contains(inputs.runsonlabels, 'self-hosted') && inputs.scheme != ''"
       run: gem install xcpretty
     - name: Cache .derivedData folder
+      if: "inputs.cacheDerivedData"
       uses: actions/cache@v3
       with:
         path: .derivedData

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -121,8 +121,8 @@ jobs:
         KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
 
         # import certificate and provisioning profile from secrets
-        echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode --output $CERTIFICATE_PATH
-        echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode --output $PP_PATH
+        echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
+        echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o $PP_PATH
 
         # create temporary keychain
         security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH


### PR DESCRIPTION
# Self-Hosted Github Action Runner Detection & Make Caching Configurable 

## :bulb: Proposed solution
- Adds a `cacheDerivedData` flag.
- Detect self-hosted GitHub runners using the `selfhosted` environment value.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

