### PR TITLE
Ignore Outcome of the Resolve Package Dependencies Step

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -142,7 +142,8 @@ jobs:
           xcodebuild \
             -scheme ${{ inputs.scheme }} \
             -resolvePackageDependencies \
-            -derivedDataPath ".derivedData"
+            -derivedDataPath ".derivedData" \
+            || true
     - name: Build and test (xcodebuild)
       if: ${{ inputs.scheme != '' }}
       run: |


### PR DESCRIPTION
# Ignore Outcome of the Resolve Package Dependencies Step

## :recycle: Current situation & Problem
- The Resolve Package Dependencies Step might sometimes fail as xcodebuild has a problem of parsing swift packages on a first try.

## :bulb: Proposed solution
This PR addresses this issue by ignoring the outcome of the package revolve step.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

