### PR TITLE
Use Path for the Artifact Upload

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -171,7 +171,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.artifactname }}
-        path: ${{ inputs.artifactname }}
+        path: ${{ inputs.path }}/${{ inputs.artifactname }}
     - name: Clean up keychain and provisioning profile
       if: "(inputs.setupsigning && env.selfhosted) || failure()"
       run: |


### PR DESCRIPTION
# Use Path for the Artifact Upload

## :bulb: Proposed solution
- Uses the path for the artifact upload.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

