### PR TITLE
Enable Xcode Select on Self-Hosted Runners

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -107,7 +107,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: maxim-lobanov/setup-xcode@v1
-      if: "!env.selfhosted"
       with:
         xcode-version: ${{ inputs.xcodeversion }}
     - name: Check environment


### PR DESCRIPTION
# Enable Xcode Select on Self-Hosted Runners

## :bulb: Current situation & Proposed solution
- Enables the selection of an Xcode release on self-hosted runners based on the new setup in https://github.com/StanfordBDHG/VirtualMachine


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

