### PR TITLE
Use macOS 13 for the Upload of Coverage Reports

### DIFF
--- a/.github/workflows/create-and-upload-coverage-report.yml
+++ b/.github/workflows/create-and-upload-coverage-report.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   create-and-upload-coverage-report:
     name: Create and upload coverage report
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v3
     - uses: maxim-lobanov/setup-xcode@v1


### PR DESCRIPTION
# Use macOS 13 for the Upload of Coverage Reports

## :recycle: Current situation & Problem
- The current setup uses an old version of Xcode and macOS to upload coverage reports.

## :bulb: Proposed solution
- Switches the new version to macOS 13


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

