### PR TITLE
Use macOS 13 as the Default Runner on GitHub Hosted Action Runners

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -20,7 +20,7 @@ on:
         description: 'JSON-based collection of labels indicating which type of github runner should be chosen'
         required: false
         type: string
-        default: '["macos-latest"]'
+        default: '["macos-13"]'
       xcodeversion:
         description: 'The Xcode version used for the build'
         required: false


### PR DESCRIPTION
# Use macOS 13 as the Default Runner on GitHub Hosted Action Runners

## :bulb: Proposed solution
- Uses macOS 13 as the default OS


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

