### PR TITLE
Add ability to specify PAT and submodule inputs for checkout action

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -81,10 +81,6 @@ on:
         required: false
         type: boolean
         default: false
-      checkout_token:
-        description: "The Personal access token (PAT) to use with the checkout action"
-        required: false
-        type: string
       checkout_submodules:
         description: "Flag indicating if submodules should be automatically checked out."
         required: false
@@ -114,6 +110,9 @@ on:
       APPLE_ID:
         description: 'The Apple ID you use to access the App Store Connect API.'
         required: false
+      checkout_token:
+        description: "The Personal access token (PAT) to use with the checkout action"
+        required: false
 
 jobs:
   build_and_test:
@@ -125,7 +124,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        token: ${{ inputs.checkout_token }}
+        token: ${{ secrets.checkout_token }}
         submodules: ${{ inputs.checkout_submodules }}
     - uses: maxim-lobanov/setup-xcode@v1
       with:

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -81,6 +81,14 @@ on:
         required: false
         type: boolean
         default: false
+      checkout_token:
+        description: "The Personal access token (PAT) to use with the checkout action"
+        required: false
+        type: string
+      checkout_submodules:
+        description: "Flag indicating if submodules should be automatically checked out."
+        required: false
+        type: boolean
     secrets:
       BUILD_CERTIFICATE_BASE64:
         description: 'The Base64 version of the Apple signing certificate to build your iOS application.'
@@ -115,7 +123,10 @@ jobs:
       run:
         working-directory: ${{ inputs.path }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        token: ${{ inputs.checkout_token }}
+        submodules: ${{ inputs.checkout_submodules }}
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: ${{ inputs.xcodeversion }}


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign Digital Health Group open-source organization

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Add ability to specify PAT and submodule inputs for checkout action

## :recycle: Current situation & Problem
Currently, it is not possible to modify the behavior of the `actions/checkout` step of the `xcodebuild-or-fastlane` workflow. This might be desired for more custom project setup where, e.g., submodules should be checked out.

## :bulb: Proposed solution
This PR adds two new inputs to the `xcodebuild-or-fastlane` workflow to allow specifying the `token` and `submodules` option of the checkout actions to allow (1) automatic checkout of submodules and (2) allow checkout of private submodules.

## :gear: Release Notes 
* Added `checkout_token` and `checkout_submodules` inputs for the `xcodebuild-or-fastlane` workflow.

## :heavy_plus_sign: Additional Information

### Related PRs
- This is used within https://github.com/StanfordBDHG/NAMS/pull/19

### Testing
This [action run](https://github.com/StanfordBDHG/NAMS/actions/runs/6235410706/job/16924569696) verifies functionality of the updated action. The `codeql` job still runs without issue by not providing any of the new inputs and the `buildandtest` job successfully fetches the submodule using the provided PAT.

### Reviewer Nudging
This setup was tested to work in the above mentioned scenario. Here is the [workflow file](https://github.com/StanfordBDHG/NAMS/blob/25c9ed1f08fc168dcfc90a8b5e9bfb53610f3c16/.github/workflows/checkout-test.yml) for this [workflow run](https://github.com/StanfordBDHG/NAMS/actions/runs/6235205504/job/16923943900).

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

