### PR TITLE
Fix xcodebuild-or-fastlane when not supplying checkout_token

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -123,9 +123,15 @@ jobs:
         working-directory: ${{ inputs.path }}
     steps:
     - uses: actions/checkout@v4
+      if: secrets.checkout_token != ''
       with:
         token: ${{ secrets.checkout_token }}
         submodules: ${{ inputs.checkout_submodules }}
+    - uses: actions/checkout@v4
+      if: secrets.checkout_token == ''
+      with:
+        submodules: ${{ inputs.checkout_submodules }}
+
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: ${{ inputs.xcodeversion }}

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -123,13 +123,9 @@ jobs:
         working-directory: ${{ inputs.path }}
     steps:
     - uses: actions/checkout@v4
-      if: secrets.checkout_token != ''
       with:
-        token: ${{ secrets.checkout_token }}
-        submodules: ${{ inputs.checkout_submodules }}
-    - uses: actions/checkout@v4
-      if: secrets.checkout_token == ''
-      with:
+        # This is GitHubs way of implementing ternary expressions (see https://docs.github.com/en/actions/learn-github-actions/expressions)
+        token: ${{ secrets.checkout_token != '' && secrets.checkout_token || github.token }}
         submodules: ${{ inputs.checkout_submodules }}
 
     - uses: maxim-lobanov/setup-xcode@v1


### PR DESCRIPTION
# Fix xcodebuild-or-fastlane when not supplying checkout_token

## :recycle: Current situation & Problem
Recent PR #29 added the functionality to supply a PAT for checkout. This functionality was tested wrongfully (oversight where one confused the successful xcodebuild-or-fastlane of `StanfordSpezi/.github` with this repo).

## :bulb: Proposed solution
This PR addresses the issue when not supplying a `checkout_token` by specifying the default `gitHub.token`. The checkout action failed to do so when supplying an empty token.

## :gear: Release Notes 
* Fixed an issue with executing the `xcodebuild-or-fastlane` action when not supplying a `checkout_token`.

## :heavy_plus_sign: Additional Information

### Related PRs
Originally implemented in #29.

### Testing
Functionality was verified by [this CI run](https://github.com/StanfordBDHG/NAMS/actions/runs/6303304333/job/17112269072). The CodeQL step runs the action without supplying a `checkout_token`.
This time it was taken care of the CodeQL action runs the same `xcodebuild-or-fastlane` workflow from this repository (see https://github.com/StanfordBDHG/NAMS/pull/19/commits/f98bcff78f9af18a29fde5ded9db3bf9e6e88fc5).

### Reviewer Nudging
--

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

