### PR TITLE
Updates to the Latest Set of iOS Simulators as Default Values

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -35,7 +35,7 @@ on:
         description: 'The destination parameter that should be passed to xcodebuild. Defaults to the iOS simulator using an iPhone 14 Pro'
         required: false
         type: string
-        default: 'platform=iOS Simulator,name=iPhone 14 Pro'
+        default: 'platform=iOS Simulator,name=iPhone 15 Pro'
       resultBundle:
         description: 'The name of the Xcode result bundle that is passed to xcodebuild. If not defined, the name of the scheme + .xcresult is used.'
         required: false


### PR DESCRIPTION
# Updates to the Latest Set of iOS Simulators as Default Values


## :gear: Release Notes 
- Updates the default destination from the iPhone 14 Pro to iPhone 15 Pro.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
