### PR TITLE
Add Firebase Deployment GitHub Actions and Capabilities

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -1,0 +1,56 @@
+#
+# This source file is part of the Stanford Biodesign Digital Health Group open-source organization
+#
+# SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+name: Test using xcodebuild or run fastlane
+
+on:
+  workflow_call:
+    inputs:
+      path:
+        description: 'The path where the project is located. Defaults to $GITHUB_WORKSPACE'
+        required: false
+        type: string
+        default: '.'
+      arguments:
+        description: 'Arguments passed to the firebase deploy command'
+        required: false
+        type: string
+        default: ''
+    secrets:
+      GOOGLE_APPLICATION_CREDENTIALS_BASE64:
+        description: 'The Base64 version of the private key JSON file for the service account. You can lean more about how to generate the JSON at https://firebase.google.com/docs/app-distribution/authenticate-service-account. The service account must have the minimally required permissions as documented at https://firebase.google.com/docs/projects/iam/roles-predefined.'
+        required: true
+
+jobs:
+  deployfirebase:
+    name: Deploy Firebase Project
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.path }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup NodeJS
+      uses: actions/setup-node@v3
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'microsoft'
+        java-version: '17'
+    - name: Install Firebase CLI Tools
+      run: npm install -g firebase-tools
+    - name: Deploy to Firebase
+      run: |
+        echo -n "${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}" | base64 -d > "$RUNNER_TEMP/google-application-credentials.json"
+        export GOOGLE_APPLICATION_CREDENTIALS="$RUNNER_TEMP/google-application-credentials.json"
+        echo "Stored the Google application credentials at $GOOGLE_APPLICATION_CREDENTIALS"
+        firebase deploy ${{ inputs.arguments }}
+    - name: Clean up Google application credentials
+      if: always()
+      run: |
+        rm -rf $RUNNER_TEMP/google-application-credentials.json || true

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -76,6 +76,11 @@ on:
         required: false
         type: boolean
         default: false
+      googleserviceinfoplistpath:
+        description: 'Path to the GoogleService-Info.plist file that is replaced using the content found in the secret GOOGLE_SERVICE_INFO_PLIST'
+        required: false
+        type: string
+        default: ''
       codeql:
         description: 'Use CodeQL code scanning'
         required: false
@@ -114,7 +119,10 @@ on:
         description: 'The Apple ID you use to access the App Store Connect API.'
         required: false
       CHECKOUT_TOKEN:
-        description: "The Personal access token (PAT) to use with the checkout action"
+        description: 'The Personal access token (PAT) to use with the checkout action'
+        required: false
+      GOOGLE_SERVICE_INFO_PLIST_BASE64:
+        description: 'The Base64 version of the GoogleService-Info.plist file that is used to replace the file found at googleserviceinfoplistpath if the arguemnt is set.'
         required: false
 
 jobs:
@@ -206,6 +214,10 @@ jobs:
           SECONDARY_UUID=`grep UUID -A1 -a $PP_SECONDARY_PATH | grep -io "[-A-F0-9]\{36\}"`
           cp $PP_SECONDARY_PATH ~/Library/MobileDevice/Provisioning\ Profiles/$SECONDARY_UUID.mobileprovision
         fi
+    - name: Setup Google Services File
+      if: ${{ inputs.googleserviceinfoplistpath != '' }}
+      run: |
+        echo -n "${{ secrets.GOOGLE_SERVICE_INFO_PLIST_BASE64 }}" | base64 --decode -o "${{ inputs.googleserviceinfoplistpath }}"
     - name: Initialize CodeQL
       if: ${{ !env.selfhosted && inputs.codeql }}
       uses: github/codeql-action/init@v2


### PR DESCRIPTION
# Add Firebase Deployment GitHub Actions and Capabilities

## :gear: Release Notes 
- Adds mechanism to provide a Google services info plist using GitHub secrets
- Add mechanism to deploy a firebase project using a reusable function


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
