### PR TITLE
Archive Scheme and Create XCFramework workflows

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -15,7 +15,7 @@ on:
         description: 'The path of the Xcode Workspace file (including the file extension).'
         type: string
         required: true
-      XCArchiveName:
+      xcArchiveName:
         description: 'The name of the to be created XCArchive. It must not include the default XCArchive extension ".xcarchive" as the file naming is automatically done be the workflow.'
         type: string
         required: true
@@ -24,19 +24,19 @@ on:
         type: string
         required: true
       version:
-          description: 'The version number of the XCFramework embedded in the XCArchives.'
-          type: string
-          required: true
+        description: 'The version number of the XCFramework embedded in the XCArchives.'
+        type: string
+        required: true
       configuration:
         description: 'The build configuration to use when archiving the scheme, either Debug or Release.'
         type: string
         required: false
         default: 'Release'
       runsonlabels:
-          description: 'JSON-based collection of labels indicating which type of github runner should be chosen.'
-          required: false
-          type: string
-          default: '["macos-13"]'
+        description: 'JSON-based collection of labels indicating which type of github runner should be chosen.'
+        required: false
+        type: string
+        default: '["macos-13"]'
 
 jobs:
   build-xcarchive:
@@ -46,7 +46,7 @@ jobs:
       matrix:
         sdk: [iphoneos, iphonesimulator]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
@@ -63,14 +63,14 @@ jobs:
             -scheme ${{ inputs.scheme }} \
             -configuration ${{ inputs.configuration }} \
             -sdk ${{ matrix.sdk }} \
-            -archivePath './.build/${{ inputs.XCArchiveName }}-${{ matrix.sdk }}.xcarchive' \
+            -archivePath './.build/${{ inputs.xcArchiveName }}-${{ matrix.sdk }}.xcarchive' \
             SKIP_INSTALL=NO \
             BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
             ONLY_ACTIVE_ARCH=NO \
             CI=TRUE \
-            ORK_FRAMEWORK_VERSION_NUMBER=${{ inputs.version }}
+            VERSION_NUMBER=${{ inputs.version }}
     - name: Upload Artifact
       uses: actions/upload-artifact@v3
       with:
-        name: ${{ inputs.XCArchiveName }}-${{ matrix.sdk }}.xcarchive
-        path: ./.build/${{ inputs.XCArchiveName }}-${{ matrix.sdk }}.xcarchive
+        name: ${{ inputs.xcArchiveName }}-${{ matrix.sdk }}.xcarchive
+        path: ./.build/${{ inputs.xcArchiveName }}-${{ matrix.sdk }}.xcarchive

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -11,32 +11,37 @@ name: Build XCArchive
 on:
   workflow_call:
     inputs:
-      archiveName:
-        description: 'The name of the archive'
+      workspaceFile:
+        description: 'The path of the Xcode Workspace file (including the file extension).'
         type: string
         required: true
-      workspaceFile:
-        description: 'The path to the workspace file'
+      XCArchiveName:
+        description: 'The name of the to be created XCArchive. It must not include the default XCArchive extension ".xcarchive" as the file naming is automatically done be the workflow.'
         type: string
         required: true
       scheme:
-        description: 'The scheme to archive'
+        description: 'The project scheme that should be used for the archiving process.'
         type: string
         required: true
       version:
-          description: 'The version number of the framework embedded in the XCArchives'
+          description: 'The version number of the XCFramework embedded in the XCArchives.'
           type: string
           required: true
       configuration:
-        description: 'The configuration to use when archiving the scheme'
+        description: 'The build configuration to use when archiving the scheme, either Debug or Release.'
         type: string
         required: false
         default: 'Release'
+      runsonlabels:
+          description: 'JSON-based collection of labels indicating which type of github runner should be chosen.'
+          required: false
+          type: string
+          default: '["macos-13"]'
 
 jobs:
   build-xcarchive:
     name: Build XCArchive
-    runs-on: macos-13
+    runs-on: ${{ fromJson(inputs.runsonlabels) }}
     strategy:
       matrix:
         sdk: [iphoneos, iphonesimulator]
@@ -58,7 +63,7 @@ jobs:
             -scheme ${{ inputs.scheme }} \
             -configuration ${{ inputs.configuration }} \
             -sdk ${{ matrix.sdk }} \
-            -archivePath './.build/${{ inputs.archiveName }}-${{ matrix.sdk }}.xcarchive' \
+            -archivePath './.build/${{ inputs.XCArchiveName }}-${{ matrix.sdk }}.xcarchive' \
             SKIP_INSTALL=NO \
             BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
             ONLY_ACTIVE_ARCH=NO \
@@ -67,5 +72,5 @@ jobs:
     - name: Upload Artifact
       uses: actions/upload-artifact@v3
       with:
-        name: ${{ inputs.archiveName }}-${{ matrix.sdk }}.xcarchive
-        path: ./.build/${{ inputs.archiveName }}-${{ matrix.sdk }}.xcarchive
+        name: ${{ inputs.XCArchiveName }}-${{ matrix.sdk }}.xcarchive
+        path: ./.build/${{ inputs.XCArchiveName }}-${{ matrix.sdk }}.xcarchive

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -9,8 +9,6 @@
 name: Build XCArchive
 
 on:
-  pull_request:
-  workflow_dispatch:
   workflow_call:
     inputs:
       archiveName:

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -1,0 +1,73 @@
+#
+# This source file is part of the Stanford Biodesign Digital Health Group open-source organization
+#
+# SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+name: Build XCArchive
+
+on:
+  pull_request:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      archiveName:
+        description: 'The name of the archive'
+        type: string
+        required: true
+      workspaceFile:
+        description: 'The path to the workspace file'
+        type: string
+        required: true
+      scheme:
+        description: 'The scheme to archive'
+        type: string
+        required: true
+      version:
+          description: 'The version number of the framework embedded in the XCArchives'
+          type: string
+          required: true
+      configuration:
+        description: 'The configuration to use when archiving the scheme'
+        type: string
+        required: false
+        default: 'Release'
+
+jobs:
+  build-xcarchive:
+    name: Build XCArchive
+    runs-on: macos-13
+    strategy:
+      matrix:
+        sdk: [iphoneos, iphonesimulator]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+    - name: Check environment
+      run: |
+          xcodebuild -version
+          swift --version
+          echo Release version: ${{ inputs.version }}
+          echo SDK: ${{ matrix.sdk }}
+    - name: Archive for iOS 
+      run: |
+          xcodebuild archive \
+            -workspace ${{ inputs.workspaceFile }} \
+            -scheme ${{ inputs.scheme }} \
+            -configuration ${{ inputs.configuration }} \
+            -sdk ${{ matrix.sdk }} \
+            -archivePath './.build/${{ inputs.archiveName }}-${{ matrix.sdk }}.xcarchive' \
+            SKIP_INSTALL=NO \
+            BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+            ONLY_ACTIVE_ARCH=NO \
+            CI=TRUE \
+            ORK_FRAMEWORK_VERSION_NUMBER=${{ inputs.version }}
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ inputs.archiveName }}-${{ matrix.sdk }}.xcarchive
+        path: ./.build/${{ inputs.archiveName }}-${{ matrix.sdk }}.xcarchive

--- a/.github/workflows/xcframework.yml
+++ b/.github/workflows/xcframework.yml
@@ -9,7 +9,7 @@
 name: Release
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       xcFrameworkName:
         description: 'The name of the XCFramework'

--- a/.github/workflows/xcframework.yml
+++ b/.github/workflows/xcframework.yml
@@ -6,50 +6,57 @@
 # SPDX-License-Identifier: MIT
 #
 
-name: Release
+name: Create XCFramework and Release
 
 on:
   workflow_call:
     inputs:
-      xcFrameworkName:
-        description: 'The name of the XCFramework'
-        type: string
-        required: true
-      archiveName:
-        description: 'The name of the archive'
-        type: string
-        required: true
       workspaceFile:
-        description: 'The path to the workspace file'
+        description: 'The path of the Xcode Workspace file (including the file extension).'
+        type: string
+        required: true
+      XCFrameworkName:
+        description: 'The name of the to be created XCFramework. It must not include the default XCFramework extension ".xcframework" as the file naming is automatically done be the workflow.'
+        type: string
+        required: true
+      XCArchiveName:
+        description: 'The name of the to be created XCArchive. It must not include the default XCArchive extension ".xcarchive" as the file naming is automatically done be the workflow.'
         type: string
         required: true
       scheme:
-        description: 'The scheme to archive'
+        description: 'The project scheme that should be used for the archiving process.'
         type: string
         required: true
       version:
-          description: 'The version number of the framework embedded in the XCArchives'
+          description: 'The version number of the XCFramework embedded in the XCArchives. This version number is also used for the release tag.'
           type: string
           required: true
       configuration:
-        description: 'The configuration to use when archiving the scheme'
+        description: 'The build configuration to use when archiving the scheme, either Debug or Release.'
         type: string
         required: false
         default: 'Release'
+      runsonlabels:
+          description: 'JSON-based collection of labels indicating which type of github runner should be chosen.'
+          required: false
+          type: string
+          default: '["macos-13"]'
+  
 
 jobs:
   build-xcarchive:
     name: Build XCArchive
     uses: ./.github/workflows/archive.yml
     with:
-      archiveName: ${{ inputs.archiveName }}
+      archiveName: ${{ inputs.XCArchiveName }}
       workspaceFile: ${{ inputs.workspaceFile }}
       scheme: ${{ inputs.scheme }}
       version: ${{ inputs.version }}
       configuration: ${{ inputs.configuration }}
-  create-xcframework:
+      runs-on: ${{ fromJson(inputs.runsonlabels) }}
+  create-xcframework-and-release:
     name: Build XCFramework
-    runs-on: macos-13
+    runs-on: ${{ fromJson(inputs.runsonlabels) }}
     needs: build-xcarchive
     steps:
     - uses: actions/checkout@v3
@@ -66,26 +73,26 @@ jobs:
         path: ./.build
     - name: Create XCFramework
       run: |
-          rm -rf ${{ inputs.xcFrameworkName }}.xcframework
+          rm -rf ${{ inputs.XCFrameworkName }}.xcframework
           xcodebuild -create-xcframework \
-            -framework ./.build/${{ inputs.archiveName }}-iphoneos.xcarchive/Products/Library/Frameworks/${{ inputs.archiveName }}.framework \
-            -framework ./.build/${{ inputs.archiveName }}-iphonesimulator.xcarchive/Products/Library/Frameworks/${{ inputs.archiveName }}.framework \
-            -output ${{ inputs.xcFrameworkName }}.xcframework
+            -framework ./.build/${{ inputs.XCArchiveName }}-iphoneos.xcarchive/Products/Library/Frameworks/${{ inputs.XCArchiveName }}.framework \
+            -framework ./.build/${{ inputs.XCArchiveName }}-iphonesimulator.xcarchive/Products/Library/Frameworks/${{ inputs.XCArchiveName }}.framework \
+            -output ${{ inputs.XCFrameworkName }}.xcframework
           rm -rf .build
     - name: Commit and push XCFramework
       uses: EndBug/add-and-commit@v9
       with:
-        add: ${{ inputs.xcFrameworkName }}.xcframework
+        add: ${{ inputs.XCFrameworkName }}.xcframework
         message: Create XCFramework for release ${{ inputs.version }}
         tag: '${{ inputs.version }} --force'
         tag_push: '--force'
     - name: Create Artifacts
       run: |
-          tar -zcvf ${{ inputs.xcFrameworkName }}.xcframework.tar.gz ${{ inputs.xcFrameworkName }}.xcframework
+          tar -zcvf ${{ inputs.XCFrameworkName }}.xcframework.tar.gz ${{ inputs.XCFrameworkName }}.xcframework
     - name: Create Release
       uses: softprops/action-gh-release@v1
       with:
         tag_name: ${{ inputs.version }}
         generate_release_notes: true
         fail_on_unmatched_files: true
-        files: ${{ inputs.xcFrameworkName }}.xcframework.tar.gz
+        files: ${{ inputs.XCFrameworkName }}.xcframework.tar.gz

--- a/.github/workflows/xcframework.yml
+++ b/.github/workflows/xcframework.yml
@@ -44,7 +44,7 @@ jobs:
     name: Build XCArchive
     uses: ./.github/workflows/archive.yml
     with:
-      archiveName: ${{ inputs.XCArchiveName }}
+      archiveName: ${{ inputs.xcFrameworkName }}
       workspaceFile: ${{ inputs.workspaceFile }}
       scheme: ${{ inputs.scheme }}
       version: ${{ inputs.version }}

--- a/.github/workflows/xcframework.yml
+++ b/.github/workflows/xcframework.yml
@@ -1,0 +1,91 @@
+#
+# This source file is part of the Stanford Biodesign Digital Health Group open-source organization
+#
+# SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      xcFrameworkName:
+        description: 'The name of the XCFramework'
+        type: string
+        required: true
+      archiveName:
+        description: 'The name of the archive'
+        type: string
+        required: true
+      workspaceFile:
+        description: 'The path to the workspace file'
+        type: string
+        required: true
+      scheme:
+        description: 'The scheme to archive'
+        type: string
+        required: true
+      version:
+          description: 'The version number of the framework embedded in the XCArchives'
+          type: string
+          required: true
+      configuration:
+        description: 'The configuration to use when archiving the scheme'
+        type: string
+        required: false
+        default: 'Release'
+
+jobs:
+  build-xcarchive:
+    name: Build XCArchive
+    uses: ./.github/workflows/archive.yml
+    with:
+      archiveName: ${{ inputs.archiveName }}
+      workspaceFile: ${{ inputs.workspaceFile }}
+      scheme: ${{ inputs.scheme }}
+      version: ${{ inputs.version }}
+      configuration: ${{ inputs.configuration }}
+  create-xcframework:
+    name: Build XCFramework
+    runs-on: macos-13
+    needs: build-xcarchive
+    steps:
+    - uses: actions/checkout@v3
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+    - name: Check environment
+      run: |
+          xcodebuild -version
+          swift --version
+          echo Release version: ${{ inputs.version }}
+    - uses: actions/download-artifact@v3
+      with:
+        path: ./.build
+    - name: Create XCFramework
+      run: |
+          rm -rf ${{ inputs.xcFrameworkName }}.xcframework
+          xcodebuild -create-xcframework \
+            -framework ./.build/${{ inputs.archiveName }}-iphoneos.xcarchive/Products/Library/Frameworks/${{ inputs.archiveName }}.framework \
+            -framework ./.build/${{ inputs.archiveName }}-iphonesimulator.xcarchive/Products/Library/Frameworks/${{ inputs.archiveName }}.framework \
+            -output ${{ inputs.xcFrameworkName }}.xcframework
+          rm -rf .build
+    - name: Commit and push XCFramework
+      uses: EndBug/add-and-commit@v9
+      with:
+        add: ${{ inputs.xcFrameworkName }}.xcframework
+        message: Create XCFramework for release ${{ inputs.version }}
+        tag: '${{ inputs.version }} --force'
+        tag_push: '--force'
+    - name: Create Artifacts
+      run: |
+          tar -zcvf ${{ inputs.xcFrameworkName }}.xcframework.tar.gz ${{ inputs.xcFrameworkName }}.xcframework
+    - name: Create Release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: ${{ inputs.version }}
+        generate_release_notes: true
+        fail_on_unmatched_files: true
+        files: ${{ inputs.xcFrameworkName }}.xcframework.tar.gz

--- a/.github/workflows/xcframework.yml
+++ b/.github/workflows/xcframework.yml
@@ -15,12 +15,8 @@ on:
         description: 'The path of the Xcode Workspace file (including the file extension).'
         type: string
         required: true
-      XCFrameworkName:
+      xcFrameworkName:
         description: 'The name of the to be created XCFramework. It must not include the default XCFramework extension ".xcframework" as the file naming is automatically done be the workflow.'
-        type: string
-        required: true
-      XCArchiveName:
-        description: 'The name of the to be created XCArchive. It must not include the default XCArchive extension ".xcarchive" as the file naming is automatically done be the workflow.'
         type: string
         required: true
       scheme:
@@ -28,19 +24,19 @@ on:
         type: string
         required: true
       version:
-          description: 'The version number of the XCFramework embedded in the XCArchives. This version number is also used for the release tag.'
-          type: string
-          required: true
+        description: 'The version number of the XCFramework embedded in the XCArchives. This version number is also used for the release tag.'
+        type: string
+        required: true
       configuration:
         description: 'The build configuration to use when archiving the scheme, either Debug or Release.'
         type: string
         required: false
         default: 'Release'
       runsonlabels:
-          description: 'JSON-based collection of labels indicating which type of github runner should be chosen.'
-          required: false
-          type: string
-          default: '["macos-13"]'
+        description: 'JSON-based collection of labels indicating which type of github runner should be chosen.'
+        required: false
+        type: string
+        default: '["macos-13"]'
   
 
 jobs:
@@ -59,7 +55,7 @@ jobs:
     runs-on: ${{ fromJson(inputs.runsonlabels) }}
     needs: build-xcarchive
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
@@ -73,26 +69,26 @@ jobs:
         path: ./.build
     - name: Create XCFramework
       run: |
-          rm -rf ${{ inputs.XCFrameworkName }}.xcframework
+          rm -rf ${{ inputs.xcFrameworkName }}.xcframework
           xcodebuild -create-xcframework \
-            -framework ./.build/${{ inputs.XCArchiveName }}-iphoneos.xcarchive/Products/Library/Frameworks/${{ inputs.XCArchiveName }}.framework \
-            -framework ./.build/${{ inputs.XCArchiveName }}-iphonesimulator.xcarchive/Products/Library/Frameworks/${{ inputs.XCArchiveName }}.framework \
-            -output ${{ inputs.XCFrameworkName }}.xcframework
+            -framework ./.build/${{ inputs.xcFrameworkName }}-iphoneos.xcarchive/Products/Library/Frameworks/${{ inputs.xcFrameworkName }}.framework \
+            -framework ./.build/${{ inputs.xcFrameworkName }}-iphonesimulator.xcarchive/Products/Library/Frameworks/${{ inputs.xcFrameworkName }}.framework \
+            -output ${{ inputs.xcFrameworkName }}.xcframework
           rm -rf .build
     - name: Commit and push XCFramework
       uses: EndBug/add-and-commit@v9
       with:
-        add: ${{ inputs.XCFrameworkName }}.xcframework
+        add: ${{ inputs.xcFrameworkName }}.xcframework
         message: Create XCFramework for release ${{ inputs.version }}
         tag: '${{ inputs.version }} --force'
         tag_push: '--force'
     - name: Create Artifacts
       run: |
-          tar -zcvf ${{ inputs.XCFrameworkName }}.xcframework.tar.gz ${{ inputs.XCFrameworkName }}.xcframework
+          tar -zcvf ${{ inputs.xcFrameworkName }}.xcframework.tar.gz ${{ inputs.xcFrameworkName }}.xcframework
     - name: Create Release
       uses: softprops/action-gh-release@v1
       with:
         tag_name: ${{ inputs.version }}
         generate_release_notes: true
         fail_on_unmatched_files: true
-        files: ${{ inputs.XCFrameworkName }}.xcframework.tar.gz
+        files: ${{ inputs.xcFrameworkName }}.xcframework.tar.gz

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,3 +13,4 @@ SPDX-License-Identifier: MIT
 * [Paul Schmiedmayer](https://github.com/PSchmiedmayer)
 * [Vishnu Ravi](https://github.com/vishnuravi)
 * [Oliver Aalami](https://github.com/aalami5)
+* [Philipp Zagar](https://github.com/philippzagar)


### PR DESCRIPTION
# Archive Scheme and Create XCFramework reusable workflows

## :recycle: Current situation & Problem
At the moment, the StanfordBDHG fork of [llama.cpp](https://github.com/StanfordBDHG/llama.cpp) as well as the fork of [ResearchKit](https://github.com/StanfordBDHG/ResearchKit) require a GitHub Actions workflow that archives a scheme and creates an XCFramework that is then published in a tagged release. 
As both of these repositories need these functionalities, there is substantial code duplication.

## :gear: Release Notes 
- Add reusable GitHub Action workflows that archive a scheme and create an XCFramework.


## :books: Documentation
Provided within the GitHub Action workflow files.


## :white_check_mark: Testing
Workflows have been tested manually.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
