### PR TITLE
Commit XCFramework via PAT

### DIFF
--- a/.github/workflows/xcframework.yml
+++ b/.github/workflows/xcframework.yml
@@ -37,6 +37,15 @@ on:
         type: string
         required: false
         default: '["macos-13"]'
+      user:
+        description: 'Optional GitHub username that is associated with the GitHub Personal Access Token (PAT)'
+        type: string
+        required: false
+        default: ''
+    secrets:
+      access-token:
+        description: 'GitHub Personal Access Token (PAT) if the to-be-commited-to branch is protected and needs a specific access token to push commits to the branch'
+        required: false
   
 
 jobs:
@@ -56,6 +65,8 @@ jobs:
     needs: build-xcarchive
     steps:
     - uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.access-token || github.token }}
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
@@ -82,6 +93,9 @@ jobs:
         message: Create XCFramework for release ${{ inputs.version }}
         tag: '${{ inputs.version }} --force'
         tag_push: '--force'
+        github_token: ${{ secrets.access-token || github.token }}
+        author_name: ${{ inputs.user || github.actor }}
+        author_email: ${{ inputs.user || github.actor }}@users.noreply.github.com
     - name: Create Artifacts
       run: |
           tar -zcvf ${{ inputs.xcFrameworkName }}.xcframework.tar.gz ${{ inputs.xcFrameworkName }}.xcframework

--- a/.github/workflows/xcframework.yml
+++ b/.github/workflows/xcframework.yml
@@ -65,8 +65,6 @@ jobs:
     needs: build-xcarchive
     steps:
     - uses: actions/checkout@v4
-      with:
-        token: ${{ secrets.access-token || github.token }}
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,3 +14,4 @@ SPDX-License-Identifier: MIT
 * [Vishnu Ravi](https://github.com/vishnuravi)
 * [Oliver Aalami](https://github.com/aalami5)
 * [Philipp Zagar](https://github.com/philippzagar)
+* [Andreas Bauer](https://github.com/Supereg)

--- a/README.md
+++ b/README.md
@@ -86,6 +86,42 @@ jobs:
       user: PaulsAutomationBot
 ```
 
+### Build XCArchive
+
+A GitHub Action that builds an XCArchive based on an Xcode Workspace file with a specific scheme. The resulting archive is uploaded and stored as an artifact.
+You can learn more about the arguments in the [`archive.yml` GitHub Action file](https://github.com/StanfordBDHG/.github/blob/main/.github/workflows/archive.yml).
+
+```yml
+jobs:
+  build-xcarchive:
+    name: Build XCArchive
+    uses: StanfordBDHG/.github/.github/workflows/archive.yml@v2
+    with:
+      workspaceFile: example.xcworkspace
+      xcArchiveName: exampleXCArchiveName
+      scheme: exampleScheme
+      version: 0.1.0
+```
+
+### Create XCFramework and Release
+
+A GitHub Action that creates an XCFramework from an Xcode Workspace file with a specific scheme. As an intermediate step, the action utilizes the [`archive.yml`](https://github.com/StanfordBDHG/.github/blob/main/.github/workflows/archive.yml) reusable workflow to create the XCArchives that are packaged within the XCFramework. The resulting XCFramework is committed to the respective branch and a tagged release is created.
+You can learn more about the arguments in the [`xcframework.yml` GitHub Action file](https://github.com/StanfordBDHG/.github/blob/main/.github/workflows/xcframework.yml).
+
+```yml
+jobs:
+  create-xcframework-and-release-workflow:
+    name: Create XCFramework and Release
+    uses: StanfordBDHG/.github/.github/workflows/xcframework.yml@v2
+    with:
+      workspaceFile: example.xcworkspace
+      xcFrameworkName: exampleXCFrameworkName
+      scheme: exampleScheme
+      version: 0.1.0
+      user: PaulsAutomationBot
+    secrets:
+      access-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+```
 
 ## Continous Integration Setup
 


### PR DESCRIPTION
# Commit XCFramework via PAT

## :recycle: Current situation & Problem
At the moment, the `xcframework.yml` reusable GitHub Action commits the created XCFramework file to a respective branch with the regular GitHub Access Token that is passed to every action. However, if the respective branch has some branch protections (e.g. on the `main` branch), the default access rights of the token won't be sufficient. 


## :gear: Release Notes 
- XCFramework action now takes a [PAT](https://docs.github.com/en/enterprise-server@3.6/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) and an author name/email that are used to commit the created XCFramework file to the respective branch. 


## :books: Documentation
Included in the workflow files


## :white_check_mark: Testing
Manually tested


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
