### PR TITLE
Allows for passing secrets to the docker-compose-test workflow via a `.env` file

### DIFF
--- a/.github/workflows/docker-compose-test.yml
+++ b/.github/workflows/docker-compose-test.yml
@@ -26,6 +26,10 @@ on:
         description: 'Optional path or name to a test script to test the Docker compose setup'
         required: false
         type: string
+      secrets:
+        ENV_FILE:
+          description: 'Contents of a .env file'
+          required: false
 
 jobs:
   buildandtest:
@@ -37,6 +41,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Create .env file
+        run: |
+          echo "${{ secrets.ENV_FILE }}" > ${{ github.workspace }}/.env
       - name: Docker compose up
         run: docker-compose -f ${{ inputs.workingDirectory }}/${{ inputs.dockerComposeFile }} up -d --build
       - name: Run test script

--- a/.github/workflows/docker-compose-test.yml
+++ b/.github/workflows/docker-compose-test.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Create .env file
         run: |
-          echo "${{ secrets.ENV_FILE }}" > ${{ github.workspace }}/.env
+          echo "${{ secrets.ENV_FILE }}" > ${{ inputs.workingDirectory }}/.env
       - name: Docker compose up
         run: docker-compose -f ${{ inputs.workingDirectory }}/${{ inputs.dockerComposeFile }} up -d --build
       - name: Run test script


### PR DESCRIPTION
# Allows for passing secrets to the docker-compose-test workflow via a `.env` file

## :recycle: Current situation & Problem
We may need to pass secrets as environment variables when testing with docker, but there is currently no method to do this.

## :gear: Release Notes 
Allows setting an `ENV_FILE` secret which will be written into a `.env` file before running the `docker-compose` command.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
