### PR TITLE
Enable C++ interop archiving

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -37,6 +37,11 @@ on:
         type: string
         required: false
         default: '["macos-13"]'
+      cxxInterop:
+        description: 'Enable the compilation of the XCArchive with active Swift / C++ interoperability.'
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   build-xcarchive:
@@ -68,7 +73,8 @@ jobs:
             BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
             ONLY_ACTIVE_ARCH=NO \
             CI=TRUE \
-            VERSION_NUMBER=${{ inputs.version }}
+            VERSION_NUMBER=${{ inputs.version }} \
+            SWIFT_OBJC_INTEROP_MODE=${{ (inputs.cxxInterop && 'objcxx') || 'objc' }}
     - name: Upload Artifact
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
# Enable C++ interop archiving

## :recycle: Current situation & Problem
Currently, the reusable workflow doesn't enable compilation with active Swift / C++ interop mode.


## :gear: Release Notes 
- Enable the creation of XCArchives with active Swift / C++ interop mode via workflow parameter.


## :books: Documentation
--


## :white_check_mark: Testing
Tested with the ResearchKit repo


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
