### PR TITLE
Upgrade to new efficient artifact actions + mac code sign identity

### DIFF
--- a/.github/workflows/action-release-tag.yml
+++ b/.github/workflows/action-release-tag.yml
@@ -26,7 +26,7 @@ jobs:
     name: Action Tag Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.access-token || github.token }}

--- a/.github/workflows/create-and-upload-coverage-report.yml
+++ b/.github/workflows/create-and-upload-coverage-report.yml
@@ -25,7 +25,7 @@ jobs:
     name: Create and upload coverage report
     runs-on: macos-14
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
@@ -33,7 +33,7 @@ jobs:
       run: |
           xcodebuild -version
           swift --version
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
     - name: Rename single code coverage report
       if: "!contains(inputs.coveragereports, ' ')"
       run: |

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -16,6 +16,6 @@ jobs:
     name: REUSE Compliance Check
     runs-on: ubuntu-latest
     steps: 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: REUSE Compliance Check
       uses: fsfe/reuse-action@v1

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -16,7 +16,7 @@ jobs:
     name: SwiftLint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: SwiftLint

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -161,7 +161,7 @@ jobs:
       run: gem install xcpretty
     - name: Cache .derivedData folder
       if: ${{ inputs.cacheDerivedData }}
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: .derivedData
         key: ${{ runner.os }}-${{ runner.arch }}-derivedData-${{ hashFiles('**/Package.swift', '**/*.pbxproj') }}
@@ -169,16 +169,16 @@ jobs:
           ${{ runner.os }}-${{ runner.arch }}-derivedData-
     - name: Cache Firebase Emulators
       if: ${{ !env.selfhosted && inputs.setupfirebaseemulator }}
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/firebase/emulators
         key: ${{ runner.os }}-${{ runner.arch }}-firebase-emulators-${{ hashFiles('~/.cache/firebase/emulators/**') }}
     - name: Setup NodeJS
       if: ${{ !env.selfhosted && inputs.setupfirebaseemulator }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
     - name: Setup Java
       if: ${{ !env.selfhosted && inputs.setupfirebaseemulator }}
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'microsoft'
         java-version: '17'
@@ -360,6 +360,7 @@ jobs:
             -derivedDataPath ".derivedData" \
             -resultBundlePath "$RESULTBUNDLE" \
             CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
             OTHER_SWIFT_FLAGS="\$(inherited) $ENABLE_TESTING_FLAG" \
           | xcpretty
     - name: Fastlane
@@ -375,7 +376,7 @@ jobs:
       uses: github/codeql-action/analyze@v2
     - name: Upload artifact
       if: ${{ (success() || failure()) && inputs.artifactname != '' && inputs.buildConfig != 'Release' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifactname }}
         path: ${{ inputs.path }}/${{ inputs.artifactname }}


### PR DESCRIPTION
# Upgrade to new efficient artifact actions + mac code sign identity

## :recycle: Current situation & Problem
 
This PR upgrades the actions to the new v4 version of the upload- and download-artifact actions. This results in a dramatic speed increase when uploading and download artifacts.
The workflow files from this PR were tested within this [action run](https://github.com/StanfordBDHG/XCTestExtensions/actions/runs/7934290919). You can compare timings to the [previous run](https://github.com/StanfordBDHG/XCTestExtensions/actions/runs/7927029084). Comparing these two examples, the coverage download takes 1s instead of 24s. Uploading takes 1s instead of 8s (for a successful run with this example project). 

## :gear: Release Notes 

* Speed increase uploading and downloading code coverage artifacts.

## :books: Documentation

--

## :white_check_mark: Testing

These changes were tested in the above linked action runs.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
