### PR TITLE
Upgrade artifact actions for archive and docker actions

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -81,7 +81,7 @@ jobs:
             VERSION_NUMBER=${{ inputs.version }} \
             SWIFT_OBJC_INTEROP_MODE=${{ (inputs.cxxInterop && 'objcxx') || 'objc' }}
     - name: Upload Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.xcArchiveName }}-${{ matrix.sdk }}.xcarchive
         path: ./.build/${{ inputs.xcArchiveName }}-${{ matrix.sdk }}.xcarchive

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -105,7 +105,7 @@ jobs:
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
       - name: Upload digest
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: digests
           path: /tmp/digests/*
@@ -117,7 +117,7 @@ jobs:
       - build
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: digests
           path: /tmp/digests

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -46,7 +46,7 @@ jobs:
           markdown-report-on-step-summary: true
       - name: Upload ESLint report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: eslint_report.json
           path: eslint_report.json

--- a/.github/workflows/xcframework.yml
+++ b/.github/workflows/xcframework.yml
@@ -81,7 +81,7 @@ jobs:
           xcodebuild -version
           swift --version
           echo Release version: ${{ inputs.version }}
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         path: ./.build
     - name: Create XCFramework


### PR DESCRIPTION
# Upgrade artifact actions for archive and docker actions

## :recycle: Current situation & Problem
We upgraded our code-coverage artifact upload and download actions to use the new `v4` version (see #52). Our xcframework creation process and docker container actions still use the old, slow v3 actions. This PR upgrades them as well.


## :gear: Release Notes 
* Increased performance for file uploads in xcframework creation


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
