### PR TITLE
Preserve symlinks in XCArchives and XCFramework

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -66,7 +66,7 @@ jobs:
           swift --version
           echo Release version: ${{ inputs.version }}
           echo SDK: ${{ matrix.sdk }}
-    - name: Archive for iOS 
+    - name: Archive for respective Platform SDK
       run: |
           xcodebuild archive \
             -workspace ${{ inputs.workspaceFile }} \
@@ -80,8 +80,11 @@ jobs:
             CI=TRUE \
             VERSION_NUMBER=${{ inputs.version }} \
             SWIFT_OBJC_INTEROP_MODE=${{ (inputs.cxxInterop && 'objcxx') || 'objc' }}
+    - name: Package the XCArchive
+      run: |
+          tar -zcvf ./.build/${{ inputs.xcArchiveName }}-${{ matrix.sdk }}.xcarchive.tar.gz ./.build/${{ inputs.xcArchiveName }}-${{ matrix.sdk }}.xcarchive
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ inputs.xcArchiveName }}-${{ matrix.sdk }}.xcarchive
-        path: ./.build/${{ inputs.xcArchiveName }}-${{ matrix.sdk }}.xcarchive
+        name: ${{ inputs.xcArchiveName }}-${{ matrix.sdk }}.xcarchive.tar.gz
+        path: ./.build/${{ inputs.xcArchiveName }}-${{ matrix.sdk }}.xcarchive.tar.gz

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -82,7 +82,8 @@ jobs:
             SWIFT_OBJC_INTEROP_MODE=${{ (inputs.cxxInterop && 'objcxx') || 'objc' }}
     - name: Package the XCArchive
       run: |
-          tar -zcvf ./.build/${{ inputs.xcArchiveName }}-${{ matrix.sdk }}.xcarchive.tar.gz ./.build/${{ inputs.xcArchiveName }}-${{ matrix.sdk }}.xcarchive
+          cd ./.build
+          tar -zcvf ${{ inputs.xcArchiveName }}-${{ matrix.sdk }}.xcarchive.tar.gz ${{ inputs.xcArchiveName }}-${{ matrix.sdk }}.xcarchive
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -66,7 +66,7 @@ jobs:
           swift --version
           echo Release version: ${{ inputs.version }}
           echo SDK: ${{ matrix.sdk }}
-    - name: Archive for respective Platform SDK
+    - name: Archive for respective platform SDK
       run: |
           xcodebuild archive \
             -workspace ${{ inputs.workspaceFile }} \
@@ -80,9 +80,9 @@ jobs:
             CI=TRUE \
             VERSION_NUMBER=${{ inputs.version }} \
             SWIFT_OBJC_INTEROP_MODE=${{ (inputs.cxxInterop && 'objcxx') || 'objc' }}
-    - name: Package the XCArchive
+    - name: Package the XCArchive   # To preserve symlinks within the XCArchives that are not preserved by the GitHub Actions artifact upload
       run: |
-          cd ./.build
+          cd .build
           tar -zcvf ${{ inputs.xcArchiveName }}-${{ matrix.sdk }}.xcarchive.tar.gz ${{ inputs.xcArchiveName }}-${{ matrix.sdk }}.xcarchive
     - name: Upload Artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -66,7 +66,7 @@ jobs:
           swift --version
           echo Release version: ${{ inputs.version }}
           echo SDK: ${{ matrix.sdk }}
-    - name: Archive for respective platform SDK
+    - name: Archive for ${{ matrix.sdk }} SDK
       run: |
           xcodebuild archive \
             -workspace ${{ inputs.workspaceFile }} \

--- a/.github/workflows/xcframework.yml
+++ b/.github/workflows/xcframework.yml
@@ -89,16 +89,10 @@ jobs:
     - uses: actions/download-artifact@v4
       with:
         path: ./.build
+        merge-multiple: true
     - name: Unpack XCArchives and create XCFramework
       run: |
           rm -rf ${{ inputs.xcFrameworkName }}.xcframework
-
-          cd ./.build
-          ls -la
-          cd llama-macosx.xcarchive.tar.gz
-          ls -la
-          cd ..
-          cd ..
           
           # Convert JSON array to space-separated string
           SDK_LIST="${{ inputs.sdk }}"
@@ -109,7 +103,7 @@ jobs:
           FRAMEWORKS_ARGS=""
           for SDK in "${SDKS[@]}"; do
               # Unpack the XCArchive
-              tar -zxvf ./.build/${{ inputs.xcFrameworkName }}-${SDK}.xcarchive.tar.gz/${{ inputs.xcFrameworkName }}-${SDK}.xcarchive.tar.gz -C ./.build/
+              tar -zxvf ./.build/${{ inputs.xcFrameworkName }}-${SDK}.xcarchive.tar.gz -C ./.build/
               # Specify the path to the framework within the XCArchive
               ARCHIVE_PATH="./.build/${{ inputs.xcFrameworkName }}-${SDK}.xcarchive/Products/Library/Frameworks/${{ inputs.xcFrameworkName }}.framework"
               echo "Checking archive path: $ARCHIVE_PATH"
@@ -127,12 +121,6 @@ jobs:
           echo "Executing xcodebuild with args: $FRAMEWORKS_ARGS"
           xcodebuild -create-xcframework $FRAMEWORKS_ARGS -output ${{ inputs.xcFrameworkName }}.xcframework || { echo "xcodebuild failed"; exit 1; }
           
-          if [[ $SDK_LIST == *"macosx"* ]]; then
-            cd ${{ inputs.xcFrameworkName }}.xcframework/macos-arm64_x86_64/llama.framework/Versions
-            ls -la
-            cd ../../../../
-          fi
-
           rm -rf .build
     - name: Commit and push XCFramework
       uses: EndBug/add-and-commit@v9

--- a/.github/workflows/xcframework.yml
+++ b/.github/workflows/xcframework.yml
@@ -117,9 +117,14 @@ jobs:
           echo "Executing xcodebuild with args: $FRAMEWORKS_ARGS"
           xcodebuild -create-xcframework $FRAMEWORKS_ARGS -output ${{ inputs.xcFrameworkName }}.xcframework || { echo "xcodebuild failed"; exit 1; }
           
-          cd ${{ inputs.xcFrameworkName }}.xcframework/macos-arm64_x86_64/llama.framework/Versions
-          ls -la
+          if [[ $SDK_LIST == *"macosx"* ]]; then
+            cd ${{ inputs.xcFrameworkName }}.xcframework/macos-arm64_x86_64/llama.framework/Versions
+            ls -la
+            rm -rf Current
+            ln -s A Current
+          fi
 
+          ls -la
           cd ../../../../
 
           rm -rf .build

--- a/.github/workflows/xcframework.yml
+++ b/.github/workflows/xcframework.yml
@@ -33,7 +33,7 @@ on:
         required: false
         default: 'Release'
       dryRun:
-        description: 'If true, the workflow will not commit and release the build XCFramework.'
+        description: 'If true, the workflow will not commit and release the built XCFramework.'
         type: boolean
         required: false
         default: false

--- a/.github/workflows/xcframework.yml
+++ b/.github/workflows/xcframework.yml
@@ -32,6 +32,11 @@ on:
         type: string
         required: false
         default: 'Release'
+      dryRun:
+        description: 'If true, the workflow will not commit and release the build XCFramework.'
+        type: boolean
+        required: false
+        default: false
       runsonlabels:
         description: 'JSON-based collection of labels indicating which type of github runner should be chosen.'
         type: string
@@ -120,6 +125,7 @@ jobs:
           rm -rf .build
     - name: Commit and push XCFramework
       uses: EndBug/add-and-commit@v9
+      if: ${{ !inputs.dryRun }}
       with:
         add: ${{ inputs.xcFrameworkName }}.xcframework
         message: Create XCFramework for release ${{ inputs.version }}
@@ -133,6 +139,7 @@ jobs:
           tar -zcvf ${{ inputs.xcFrameworkName }}.xcframework.tar.gz ${{ inputs.xcFrameworkName }}.xcframework
     - name: Create Release
       uses: softprops/action-gh-release@v1
+      if: ${{ !inputs.dryRun }}
       with:
         tag_name: ${{ inputs.version }}
         generate_release_notes: true

--- a/.github/workflows/xcframework.yml
+++ b/.github/workflows/xcframework.yml
@@ -61,7 +61,7 @@ on:
 jobs:
   build-xcarchive:
     name: Build XCArchive
-    uses: StanfordBDHG/.github/.github/workflows/archive.yml@fix/xcarchive-macos
+    uses: StanfordBDHG/.github/.github/workflows/archive.yml@v2
     with:
       workspaceFile: ${{ inputs.workspaceFile }}
       xcArchiveName: ${{ inputs.xcFrameworkName }}

--- a/.github/workflows/xcframework.yml
+++ b/.github/workflows/xcframework.yml
@@ -141,6 +141,11 @@ jobs:
     - name: Create Artifacts
       run: |
           tar -zcvf ${{ inputs.xcFrameworkName }}.xcframework.tar.gz ${{ inputs.xcFrameworkName }}.xcframework
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.xcFrameworkName }}.xcframework.tar.gz
+        path: ${{ inputs.xcFrameworkName }}.xcframework.tar.gz
     - name: Create Release
       uses: softprops/action-gh-release@v1
       if: ${{ !inputs.dryRun }}

--- a/.github/workflows/xcframework.yml
+++ b/.github/workflows/xcframework.yml
@@ -61,7 +61,7 @@ on:
 jobs:
   build-xcarchive:
     name: Build XCArchive
-    uses: StanfordBDHG/.github/.github/workflows/archive.yml@@fix/xcarchive-macos
+    uses: StanfordBDHG/.github/.github/workflows/archive.yml@fix/xcarchive-macos
     with:
       workspaceFile: ${{ inputs.workspaceFile }}
       xcArchiveName: ${{ inputs.xcFrameworkName }}

--- a/.github/workflows/xcframework.yml
+++ b/.github/workflows/xcframework.yml
@@ -92,6 +92,10 @@ jobs:
     - name: Unpack XCArchives and create XCFramework
       run: |
           rm -rf ${{ inputs.xcFrameworkName }}.xcframework
+
+          cd ./.build
+          ls -la
+          cd ..
           
           # Convert JSON array to space-separated string
           SDK_LIST="${{ inputs.sdk }}"

--- a/.github/workflows/xcframework.yml
+++ b/.github/workflows/xcframework.yml
@@ -109,7 +109,7 @@ jobs:
           FRAMEWORKS_ARGS=""
           for SDK in "${SDKS[@]}"; do
               # Unpack the XCArchive
-              tar -zxvf ./.build/${{ inputs.xcFrameworkName }}-${SDK}.xcarchive.tar.gz -C ./.build/
+              tar -zxvf ./.build/${{ inputs.xcFrameworkName }}-${SDK}.xcarchive.tar.gz/${{ inputs.xcFrameworkName }}-${SDK}.xcarchive.tar.gz -C ./.build/
               # Specify the path to the framework within the XCArchive
               ARCHIVE_PATH="./.build/${{ inputs.xcFrameworkName }}-${SDK}.xcarchive/Products/Library/Frameworks/${{ inputs.xcFrameworkName }}.framework"
               echo "Checking archive path: $ARCHIVE_PATH"

--- a/.github/workflows/xcframework.yml
+++ b/.github/workflows/xcframework.yml
@@ -106,7 +106,7 @@ jobs:
           FRAMEWORKS_ARGS=""
           for SDK in "${SDKS[@]}"; do
               # Unpack the XCArchive
-              tar -zxvf ./.build/${{ inputs.xcFrameworkName }}-${SDK}.xcarchive.tar.gz -C ./.build/${{ inputs.xcFrameworkName }}-${SDK}.xcarchive
+              tar -zxvf ./.build/${{ inputs.xcFrameworkName }}-${SDK}.xcarchive.tar.gz -C ./.build/
               # Specify the path to the framework within the XCArchive
               ARCHIVE_PATH="./.build/${{ inputs.xcFrameworkName }}-${SDK}.xcarchive/Products/Library/Frameworks/${{ inputs.xcFrameworkName }}.framework"
               echo "Checking archive path: $ARCHIVE_PATH"

--- a/.github/workflows/xcframework.yml
+++ b/.github/workflows/xcframework.yml
@@ -112,6 +112,11 @@ jobs:
           echo "Executing xcodebuild with args: $FRAMEWORKS_ARGS"
           xcodebuild -create-xcframework $FRAMEWORKS_ARGS -output ${{ inputs.xcFrameworkName }}.xcframework || { echo "xcodebuild failed"; exit 1; }
           
+          cd ${{ inputs.xcFrameworkName }}.xcframework/macos-arm64_x86_64/llama.framework/Versions
+          ls -la
+
+          cd ../../../../
+
           rm -rf .build
     - name: Commit and push XCFramework
       uses: EndBug/add-and-commit@v9

--- a/.github/workflows/xcframework.yml
+++ b/.github/workflows/xcframework.yml
@@ -89,7 +89,7 @@ jobs:
     - uses: actions/download-artifact@v4
       with:
         path: ./.build
-    - name: Create XCFramework
+    - name: Unpack XCArchives and create XCFramework
       run: |
           rm -rf ${{ inputs.xcFrameworkName }}.xcframework
           
@@ -101,6 +101,9 @@ jobs:
           IFS=' ' read -r -a SDKS <<< "$SDK_LIST"
           FRAMEWORKS_ARGS=""
           for SDK in "${SDKS[@]}"; do
+              # Unpack the XCArchive
+              tar -zxvf ./.build/${{ inputs.xcFrameworkName }}-${SDK}.xcarchive.tar.gz -C ./.build/${{ inputs.xcFrameworkName }}-${SDK}.xcarchive
+              # Specify the path to the framework within the XCArchive
               ARCHIVE_PATH="./.build/${{ inputs.xcFrameworkName }}-${SDK}.xcarchive/Products/Library/Frameworks/${{ inputs.xcFrameworkName }}.framework"
               echo "Checking archive path: $ARCHIVE_PATH"
               if [ -d "$ARCHIVE_PATH" ]; then
@@ -120,12 +123,8 @@ jobs:
           if [[ $SDK_LIST == *"macosx"* ]]; then
             cd ${{ inputs.xcFrameworkName }}.xcframework/macos-arm64_x86_64/llama.framework/Versions
             ls -la
-            rm -rf Current
-            ln -s A Current
+            cd ../../../../
           fi
-
-          ls -la
-          cd ../../../../
 
           rm -rf .build
     - name: Commit and push XCFramework

--- a/.github/workflows/xcframework.yml
+++ b/.github/workflows/xcframework.yml
@@ -61,7 +61,7 @@ on:
 jobs:
   build-xcarchive:
     name: Build XCArchive
-    uses: StanfordBDHG/.github/.github/workflows/archive.yml@v2
+    uses: StanfordBDHG/.github/.github/workflows/archive.yml@@fix/xcarchive-macos
     with:
       workspaceFile: ${{ inputs.workspaceFile }}
       xcArchiveName: ${{ inputs.xcFrameworkName }}

--- a/.github/workflows/xcframework.yml
+++ b/.github/workflows/xcframework.yml
@@ -95,6 +95,9 @@ jobs:
 
           cd ./.build
           ls -la
+          cd llama-macosx.xcarchive.tar.gz
+          ls -la
+          cd ..
           cd ..
           
           # Convert JSON array to space-separated string


### PR DESCRIPTION
# Preserve symlinks in XCArchives and XCFramework

## :recycle: Current situation & Problem
Currently, the XCArchives and XCFramework actions don't preserve symlinks, resulting in build failures for using XCFrameworks on the macOS platform.


## :gear: Release Notes 
- Preserve symlinks in XCArchives and XCFramework


## :books: Documentation
-


## :white_check_mark: Testing
Tested with llama.cpp XCFramework building


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
