### PR TITLE
add flag to xcodebuild to skip package plugin validation

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -362,6 +362,7 @@ jobs:
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_IDENTITY="" \
             OTHER_SWIFT_FLAGS="\$(inherited) $ENABLE_TESTING_FLAG" \
+            -skipPackagePluginValidation \
           | xcpretty
     - name: Fastlane
       if: ${{ inputs.fastlanelane != '' }}


### PR DESCRIPTION
# Skip Package Plugin Validation

## :recycle: Current situation & Problem
Xcode projects relying on package plugins do not run successfully with our Xcode build workflow.
To resolve this issue an additional build argument should be added to skip the plugin validation.


## :gear: Release Notes 
- add build argument skipPackagePluginValidation to Xcode build command in the Xcode build workflow


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
