### PR TITLE
Fix xcresult migration

### DIFF
--- a/.github/workflows/create-and-upload-coverage-report.yml
+++ b/.github/workflows/create-and-upload-coverage-report.yml
@@ -48,5 +48,5 @@ jobs:
       with:
         fail_ci_if_error: true
         token: ${{ secrets.token }}
-        xcode: true
+        plugin: xcode
         xcode_archive_path: CodeCoverage.xcresult

--- a/.github/workflows/create-and-upload-coverage-report.yml
+++ b/.github/workflows/create-and-upload-coverage-report.yml
@@ -45,10 +45,10 @@ jobs:
           rm -rf ${{ inputs.coveragereports }}
     - name: Convert XCResult
       if: "contains(inputs.coveragereports, ' ')"
-      run: xcrun xccov view --report --json CodeCoverage.xcresult > cov.json
+      run: xcrun xccov view --report CodeCoverage.xcresult > cov.txt
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       with:
         fail_ci_if_error: true
         token: ${{ secrets.token }}
-        file: cov.json
+        file: cov.txt

--- a/.github/workflows/create-and-upload-coverage-report.yml
+++ b/.github/workflows/create-and-upload-coverage-report.yml
@@ -43,10 +43,12 @@ jobs:
       run: |
           xcrun xcresulttool merge ${{ inputs.coveragereports }} --output-path CodeCoverage.xcresult
           rm -rf ${{ inputs.coveragereports }}
+    - name: Convert XCResult
+      if: "contains(inputs.coveragereports, ' ')"
+      run: xcrun xccov view --report --json CodeCoverage.xcresult > cov.json
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       with:
         fail_ci_if_error: true
         token: ${{ secrets.token }}
-        plugin: xcode
-        xcode_archive_path: CodeCoverage.xcresult
+        file: cov.json


### PR DESCRIPTION
# Fix xcresult migration

## :recycle: Current situation & Problem
We previously relied on the codecov action to migrate our xcresult package automatically. This functionality is gone with the latest v4 release. This PR fixes the behavior by manually migrating the xcresult package.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
