### PR TITLE
Improve Automated Firebase Emulator Selection for Fastlane Builds

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -377,6 +377,13 @@ jobs:
       if: ${{ inputs.fastlanelane != '' }}
       run: |
           if ${{ inputs.setupfirebaseemulator }}; then
+              # We try to do an npm install in the functions directory.
+              npm --prefix ./functions install || true
+
+              echo -n "${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}" | base64 -d > "$RUNNER_TEMP/google-application-credentials.json"
+              export GOOGLE_APPLICATION_CREDENTIALS="$RUNNER_TEMP/google-application-credentials.json"
+              echo "Stored the Google application credentials at $GOOGLE_APPLICATION_CREDENTIALS"
+              
               if ${{ inputs.firebaseemulatorimport }}; then
                   firebase emulators:exec --import=${{ inputs.firebaseemulatorimport }} 'fastlane ${{ inputs.fastlanelane }}'
               else
@@ -390,7 +397,7 @@ jobs:
         APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
         APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
         APPLE_ID: ${{ secrets.APPLE_ID }}
-        FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        GOOGLE_APPLICATION_CREDENTIALS_BASE64: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}
     - name: Perform CodeQL Analysis
       if: ${{ !env.selfhosted && inputs.codeql }}
       uses: github/codeql-action/analyze@v2
@@ -405,3 +412,7 @@ jobs:
       run: |
         security delete-keychain $RUNNER_TEMP/app-signing.keychain-db || true
         rm -rf ~/Library/MobileDevice/Provisioning\ Profiles || true
+    - name: Clean up Google application credentials
+      if: ${{ inputs.fastlanelane != '' || failure() }}
+      run: |
+        rm -rf $RUNNER_TEMP/google-application-credentials.json || true

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -82,10 +82,15 @@ on:
         type: boolean
         default: false
       setupfirebaseemulator:
-        description: 'Setup the Firebase Emulator'
+        description: 'Setup the Firebase Emulator & automatically use it for the automated fastlane commands.'
         required: false
         type: boolean
         default: false
+      firebaseemulatorimport:
+        description: 'Firebase import directory that contains Authentication, Cloud Firestore, Realtime Database and Cloud Storage data for Firebase emulators to use as a shareable, common baseline data set.'
+        required: false
+        type: string
+        default: ''
       googleserviceinfoplistpath:
         description: 'Path to the GoogleService-Info.plist file that is replaced using the content found in the secret GOOGLE_SERVICE_INFO_PLIST'
         required: false
@@ -133,6 +138,9 @@ on:
         required: false
       GOOGLE_SERVICE_INFO_PLIST_BASE64:
         description: 'The Base64 version of the GoogleService-Info.plist file that is used to replace the file found at googleserviceinfoplistpath if the arguemnt is set.'
+        required: false
+      FIREBASE_TOKEN:
+        description: 'Firebase token to use when starting the firebase emulator.'
         required: false
 
 jobs:
@@ -367,12 +375,22 @@ jobs:
           | xcpretty
     - name: Fastlane
       if: ${{ inputs.fastlanelane != '' }}
-      run: fastlane ${{ inputs.fastlanelane }}
+      run: |
+          if ${{ inputs.setupfirebaseemulator }}; then
+              if ${{ inputs.firebaseemulatorimport }}; then
+                  firebase emulators:exec --import=${{ inputs.firebaseemulatorimport }} 'fastlane ${{ inputs.fastlanelane }}'
+              else
+                  firebase emulators:exec 'fastlane ${{ inputs.fastlanelane }}'
+              fi
+          else
+              fastlane ${{ inputs.fastlanelane }}
+          fi
       env:
         APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
         APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
         APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
         APPLE_ID: ${{ secrets.APPLE_ID }}
+        FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
     - name: Perform CodeQL Analysis
       if: ${{ !env.selfhosted && inputs.codeql }}
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -139,8 +139,8 @@ on:
       GOOGLE_SERVICE_INFO_PLIST_BASE64:
         description: 'The Base64 version of the GoogleService-Info.plist file that is used to replace the file found at googleserviceinfoplistpath if the arguemnt is set.'
         required: false
-      FIREBASE_TOKEN:
-        description: 'Firebase token to use when starting the firebase emulator.'
+      GOOGLE_APPLICATION_CREDENTIALS_BASE64:
+        description: 'The Base64 version of the private key JSON file to boot up the firebase emulator to fully support the execution of cloud functions in the emulator. Only needed if cloud functions are used.'
         required: false
 
 jobs:
@@ -383,7 +383,7 @@ jobs:
               echo -n "${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}" | base64 -d > "$RUNNER_TEMP/google-application-credentials.json"
               export GOOGLE_APPLICATION_CREDENTIALS="$RUNNER_TEMP/google-application-credentials.json"
               echo "Stored the Google application credentials at $GOOGLE_APPLICATION_CREDENTIALS"
-              
+
               if ${{ inputs.firebaseemulatorimport }}; then
                   firebase emulators:exec --import=${{ inputs.firebaseemulatorimport }} 'fastlane ${{ inputs.fastlanelane }}'
               else

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -384,7 +384,7 @@ jobs:
               export GOOGLE_APPLICATION_CREDENTIALS="$RUNNER_TEMP/google-application-credentials.json"
               echo "Stored the Google application credentials at $GOOGLE_APPLICATION_CREDENTIALS"
 
-              if ${{ inputs.firebaseemulatorimport }}; then
+              if [ -z "${{ inputs.firebaseemulatorimport }}" ]; then
                   firebase emulators:exec --import=${{ inputs.firebaseemulatorimport }} 'fastlane ${{ inputs.fastlanelane }}'
               else
                   firebase emulators:exec 'fastlane ${{ inputs.fastlanelane }}'

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -384,7 +384,8 @@ jobs:
               export GOOGLE_APPLICATION_CREDENTIALS="$RUNNER_TEMP/google-application-credentials.json"
               echo "Stored the Google application credentials at $GOOGLE_APPLICATION_CREDENTIALS"
 
-              if [ -z "${{ inputs.firebaseemulatorimport }}" ]; then
+              if [ -n "${{ inputs.firebaseemulatorimport }}" ]; then
+                  echo "Importing firebase emulator data from ${{ inputs.firebaseemulatorimport }}"
                   firebase emulators:exec --import=${{ inputs.firebaseemulatorimport }} 'fastlane ${{ inputs.fastlanelane }}'
               else
                   firebase emulators:exec 'fastlane ${{ inputs.fastlanelane }}'


### PR DESCRIPTION
# Improve Automated Firebase Emulator Selection for Fastlane Builds


## :gear: Release Notes 
- Improve Automated Firebase Emulator Selection for Fastlane Builds
- Fixes an issue where cloud functions were not properly executed as they required a fully configured Admin SDK including permissions of a service account (https://github.com/StanfordBDHG/PediatricAppleWatchStudy/pull/55)


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
