### PR TITLE
Update eslint.yml with contents read permissions for private reposito…

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -19,6 +19,7 @@ on:
 
 permissions:
   checks: write
+  contents: read
 
 jobs:
   eslint:


### PR DESCRIPTION
# Update eslint action permissions

## :recycle: Current situation & Problem
For private repositories, the eslint action currently does not work as `contents: read` permissions are required for this.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
