### PR TITLE
Fix ESLint Fork Setup

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -38,7 +38,21 @@ jobs:
       - name: Save Code Linting Report JSON
         run: npm run lint:ci
         continue-on-error: true
+      - name: Check if PR is from a fork
+        id: fork-check
+        run: |
+          if [[ ${{ github.event_name }} == 'pull_request' && ${{ github.event.pull_request.head.repo.fork }} == 'true' ]]; then
+            echo "is_fork=true" >> $GITHUB_STATE
+          else
+            echo "is_fork=false" >> $GITHUB_STATE
+          fi
+      - name: Run ESLint if PR is from a fork
+        if: env.is_fork == 'true'
+        run: npm run lint:ci && npx eslint .
+        env:
+          CI: TRUE
       - name: Annotate Code Linting Results
+        if: env.is_fork == 'false'
         uses: ataylorme/eslint-annotate-action@v2
         with:
           only-pr-files: false


### PR DESCRIPTION
# Fix ESLint Fork Setup

## :gear: Release Notes 
- Addresses a permissions errors that `GITHUB_TOKEN` doesn't have permissions to write checks form a public fork. CC: @arkadiuszbachorski


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
