### PR TITLE
Add Working Directory Option to the Test and Coverage NPM Workflow

### DIFF
--- a/.github/workflows/npm-test-and-coverage.yml
+++ b/.github/workflows/npm-test-and-coverage.yml
@@ -16,6 +16,11 @@ on:
         required: false
         type: string
         default: '18'
+      working-directory:
+        description: 'The working directory where the project is located. Defaults to $GITHUB_WORKSPACE'
+        required: false
+        type: string
+        default: '.'
     secrets:
       token:
         description: 'The CodeCov token used for private repositories'
@@ -24,6 +29,9 @@ on:
 jobs:
   testandcoverage:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node


### PR DESCRIPTION
# Add Working Directory Option to the Test and Coverage NPM Workflow

## :recycle: Current situation & Problem
- There is currently no way to use a different working directory for the GitHub action.


## :gear: Release Notes 
- Add Working Directory Option to the Test and Coverage NPM Workflow

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
