### PR TITLE
Update to Docker Compose V2

### DIFF
--- a/.github/workflows/docker-compose-test.yml
+++ b/.github/workflows/docker-compose-test.yml
@@ -1,6 +1,6 @@
 #
 # This source file is part of the Stanford Biodesign Digital Health Group open-source organization
-# Based on the Apodini workflow found at: https://github.com/Apodini/.github/workflows/docker-compose-test.yml
+# Based on the Apodini workflow found at: https://github.com/Apodini/.github/workflows/docker compose-test.yml
 #
 # SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 #
@@ -13,10 +13,10 @@ on:
   workflow_call:
     inputs:
       dockerComposeFile:
-        description: 'Path or name of the Docker compose file. The default values is `docker-compose.yml`'
+        description: 'Path or name of the Docker compose file. The default values is `docker compose.yml`'
         required: false
         type: string
-        default: 'docker-compose.yml'
+        default: 'docker compose.yml'
       workingDirectory:
         description: 'The workingDirectory of the GitHub Action. Defaults to $GITHUB_WORKSPACE'
         required: false
@@ -45,7 +45,7 @@ jobs:
         run: |
           echo "${{ secrets.ENV_FILE }}" > ${{ inputs.workingDirectory }}/.env
       - name: Docker compose up
-        run: docker-compose -f ${{ inputs.workingDirectory }}/${{ inputs.dockerComposeFile }} up -d --build
+        run: docker compose -f ${{ inputs.workingDirectory }}/${{ inputs.dockerComposeFile }} up -d --build
       - name: Run test script
         if: inputs.testscript != ''
         run: |
@@ -53,4 +53,4 @@ jobs:
           sh ${{ inputs.testscript }}
       - name: Docker compose down
         if: always()
-        run: docker-compose down
+        run: docker compose down


### PR DESCRIPTION
# Update to Docker Compose V2

## :recycle: Current situation & Problem
- Docker builds are failing in https://github.com/StanfordBDHG/ENGAGE-HF-Web-Frontend/pull/25 due to an old `docker-compose` command.

## :gear: Release Notes 
- Updates the docker compose command to v2 using the docker command.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
