### PR TITLE
Add input for custom command in firebase emulators:exec

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -122,20 +122,6 @@ on:
         required: false
         type: boolean
         default: false
-      firebasejsonpath:
-        description: |
-          Path to the firebase.json file that is used to configure the Firebase Emulator.
-          Defaults to './firebase.json' in the root directory.
-        required: false
-        type: string
-        default: ''
-      customfirebaseemulatorcommand:
-        description: |
-          A custom command that should be run right before executing the fastlane command.
-          Only used if `setupfirebaseemulator` is set to true, 'fastlanelane' is set, and no `firebaseemulatorimport` is set.
-        required: false
-        type: string
-        default: ''
       firebaseemulatorimport:
         description: |
           Firebase import directory that contains Authentication, Cloud Firestore, Realtime Database and Cloud Storage data for Firebase emulators.
@@ -386,22 +372,11 @@ jobs:
                 export GOOGLE_APPLICATION_CREDENTIALS="$RUNNER_TEMP/google-application-credentials.json"
                 echo "Stored the Google application credentials at $GOOGLE_APPLICATION_CREDENTIALS"
 
-                # Use the custom path to the firebase.json file if provided.
-                if [ -n "${{ inputs.firebasejsonpath }}" ]; then
-                    export FIREBASE_JSON_PATH="${{ inputs.firebasejsonpath }}"
-                else
-                    export FIREBASE_JSON_PATH="./firebase.json"
-                fi
-
                 if [ -n "${{ inputs.firebaseemulatorimport }}" ]; then
                     echo "Importing firebase emulator data from ${{ inputs.firebaseemulatorimport }}"
-                    firebase emulators:exec -c $FIREBASE_JSON_PATH --import=${{ inputs.firebaseemulatorimport }} 'fastlane ${{ inputs.fastlanelane }}'
+                    firebase emulators:exec --import=${{ inputs.firebaseemulatorimport }} 'fastlane ${{ inputs.fastlanelane }}'
                 else
-                    if [ -n "${{ inputs.customfirebaseemulatorcommand }}" ]; then
-                        firebase emulators:exec -c $FIREBASE_JSON_PATH '${{ inputs.customfirebaseemulatorcommand }} && fastlane ${{ inputs.fastlanelane }}'
-                    else
-                      firebase emulators:exec -c $FIREBASE_JSON_PATH 'fastlane ${{ inputs.fastlanelane }}'
-                    fi
+                    firebase emulators:exec 'fastlane ${{ inputs.fastlanelane }}'
                 fi
             else
                 fastlane ${{ inputs.fastlanelane }}

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -407,6 +407,7 @@ jobs:
                 fastlane ${{ inputs.fastlanelane }}
             fi
         env:
+          FIREBASE_JSON_PATH: "./firebase.json"
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -388,19 +388,19 @@ jobs:
 
                 # Use the custom path to the firebase.json file if provided.
                 if [ -n "${{ inputs.firebasejsonpath }}" ]; then
-                    firebaseJSONPath = ${{ inputs.firebasejsonpath }}
+                    export FIREBASE_JSON_PATH="${{ inputs.firebasejsonpath }}"
                 else
-                    firebaseJSONPath = "./firebase.json"
+                    export FIREBASE_JSON_PATH="./firebase.json"
                 fi
 
                 if [ -n "${{ inputs.firebaseemulatorimport }}" ]; then
                     echo "Importing firebase emulator data from ${{ inputs.firebaseemulatorimport }}"
-                    firebase emulators:exec -c firebaseJSONPath --import=${{ inputs.firebaseemulatorimport }} 'fastlane ${{ inputs.fastlanelane }}'
+                    firebase emulators:exec -c FIREBASE_JSON_PATH --import=${{ inputs.firebaseemulatorimport }} 'fastlane ${{ inputs.fastlanelane }}'
                 else
                     if [ -n "${{ inputs.customfirebaseemulatorcommand }}" ]; then
-                        firebase emulators:exec -c firebaseJSONPath '${{ inputs.customfirebaseemulatorcommand }} && fastlane ${{ inputs.fastlanelane }}'
+                        firebase emulators:exec -c FIREBASE_JSON_PATH '${{ inputs.customfirebaseemulatorcommand }} && fastlane ${{ inputs.fastlanelane }}'
                     else
-                      firebase emulators:exec -c firebaseJSONPath 'fastlane ${{ inputs.fastlanelane }}'
+                      firebase emulators:exec -c FIREBASE_JSON_PATH 'fastlane ${{ inputs.fastlanelane }}'
                     fi
                 fi
             else

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -122,6 +122,13 @@ on:
         required: false
         type: boolean
         default: false
+      firebasejsonpath:
+        description: |
+          Path to the firebase.json file that is used to configure the Firebase Emulator.
+          Defaults to './firebase.json' in the root directory.
+        required: false
+        type: string
+        default: ''
       customfirebaseemulatorcommand:
         description: |
           A custom command that should be run right before executing the fastlane command.
@@ -379,14 +386,21 @@ jobs:
                 export GOOGLE_APPLICATION_CREDENTIALS="$RUNNER_TEMP/google-application-credentials.json"
                 echo "Stored the Google application credentials at $GOOGLE_APPLICATION_CREDENTIALS"
 
+                # Use the custom path to the firebase.json file if provided.
+                if [ -n "${{ inputs.firebasejsonpath }}" ]; then
+                    firebaseJSONPath = ${{ inputs.firebasejsonpath }}
+                else
+                    firebaseJSONPath = "./firebase.json"
+                fi
+
                 if [ -n "${{ inputs.firebaseemulatorimport }}" ]; then
                     echo "Importing firebase emulator data from ${{ inputs.firebaseemulatorimport }}"
-                    firebase emulators:exec --import=${{ inputs.firebaseemulatorimport }} 'fastlane ${{ inputs.fastlanelane }}'
+                    firebase emulators:exec -c firebaseJSONPath --import=${{ inputs.firebaseemulatorimport }} 'fastlane ${{ inputs.fastlanelane }}'
                 else
                     if [ -n "${{ inputs.customfirebaseemulatorcommand }}" ]; then
-                        firebase emulators:exec '${{ inputs.customfirebaseemulatorcommand }} && fastlane ${{ inputs.fastlanelane }}'
+                        firebase emulators:exec -c firebaseJSONPath '${{ inputs.customfirebaseemulatorcommand }} && fastlane ${{ inputs.fastlanelane }}'
                     else
-                      firebase emulators:exec 'fastlane ${{ inputs.fastlanelane }}'
+                      firebase emulators:exec -c firebaseJSONPath 'fastlane ${{ inputs.fastlanelane }}'
                     fi
                 fi
             else

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -395,19 +395,18 @@ jobs:
 
                 if [ -n "${{ inputs.firebaseemulatorimport }}" ]; then
                     echo "Importing firebase emulator data from ${{ inputs.firebaseemulatorimport }}"
-                    firebase emulators:exec -c FIREBASE_JSON_PATH --import=${{ inputs.firebaseemulatorimport }} 'fastlane ${{ inputs.fastlanelane }}'
+                    firebase emulators:exec -c $FIREBASE_JSON_PATH --import=${{ inputs.firebaseemulatorimport }} 'fastlane ${{ inputs.fastlanelane }}'
                 else
                     if [ -n "${{ inputs.customfirebaseemulatorcommand }}" ]; then
-                        firebase emulators:exec -c FIREBASE_JSON_PATH '${{ inputs.customfirebaseemulatorcommand }} && fastlane ${{ inputs.fastlanelane }}'
+                        firebase emulators:exec -c $FIREBASE_JSON_PATH '${{ inputs.customfirebaseemulatorcommand }} && fastlane ${{ inputs.fastlanelane }}'
                     else
-                      firebase emulators:exec -c FIREBASE_JSON_PATH 'fastlane ${{ inputs.fastlanelane }}'
+                      firebase emulators:exec -c $FIREBASE_JSON_PATH 'fastlane ${{ inputs.fastlanelane }}'
                     fi
                 fi
             else
                 fastlane ${{ inputs.fastlanelane }}
             fi
         env:
-          FIREBASE_JSON_PATH: "./firebase.json"
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -387,6 +387,7 @@ jobs:
                         firebase emulators:exec '${{ inputs.customfirebaseemulatorcommand }} && fastlane ${{ inputs.fastlanelane }}'
                     else
                       firebase emulators:exec 'fastlane ${{ inputs.fastlanelane }}'
+                    fi
                 fi
             else
                 fastlane ${{ inputs.fastlanelane }}

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -122,6 +122,13 @@ on:
         required: false
         type: boolean
         default: false
+      customfirebaseemulatorcommand:
+        description: |
+          A custom command that should be run right before executing the fastlane command.
+          Only used if `setupfirebaseemulator` is set to true, 'fastlanelane' is set, and no `firebaseemulatorimport` is set.
+        required: false
+        type: string
+        default: ''
       firebaseemulatorimport:
         description: |
           Firebase import directory that contains Authentication, Cloud Firestore, Realtime Database and Cloud Storage data for Firebase emulators.
@@ -376,7 +383,10 @@ jobs:
                     echo "Importing firebase emulator data from ${{ inputs.firebaseemulatorimport }}"
                     firebase emulators:exec --import=${{ inputs.firebaseemulatorimport }} 'fastlane ${{ inputs.fastlanelane }}'
                 else
-                    firebase emulators:exec 'fastlane ${{ inputs.fastlanelane }}'
+                    if [ -n "${{ inputs.customfirebaseemulatorcommand }}" ]; then
+                        firebase emulators:exec '${{ inputs.customfirebaseemulatorcommand }} && fastlane ${{ inputs.fastlanelane }}'
+                    else
+                      firebase emulators:exec 'fastlane ${{ inputs.fastlanelane }}'
                 fi
             else
                 fastlane ${{ inputs.fastlanelane }}

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -129,6 +129,13 @@ on:
         required: false
         type: string
         default: ''
+      firebasejsonpath:
+        description: |
+          Path to the firebase.json file that is used to boot up the firebase emulator.
+          Defaults to the root of the project.
+        required: false
+        type: string
+        default: './firebase.json'
       googleserviceinfoplistpath:
         description: |
           Path to the GoogleService-Info.plist file that is replaced using the content found in the secret GOOGLE_SERVICE_INFO_PLIST.
@@ -374,9 +381,9 @@ jobs:
 
                 if [ -n "${{ inputs.firebaseemulatorimport }}" ]; then
                     echo "Importing firebase emulator data from ${{ inputs.firebaseemulatorimport }}"
-                    firebase emulators:exec --import=${{ inputs.firebaseemulatorimport }} 'fastlane ${{ inputs.fastlanelane }}'
+                    firebase emulators:exec -c ${{ inputs.firebasejsonpath }} --import=${{ inputs.firebaseemulatorimport }} 'fastlane ${{ inputs.fastlanelane }}'
                 else
-                    firebase emulators:exec 'fastlane ${{ inputs.fastlanelane }}'
+                    firebase emulators:exec -c ${{ inputs.firebasejsonpath }} 'fastlane ${{ inputs.fastlanelane }}'
                 fi
             else
                 fastlane ${{ inputs.fastlanelane }}


### PR DESCRIPTION
# Add option to run custom command right before fastlane in emulator execution.

## :recycle: Current situation & Problem
In the ENGAGE-HF project, when we seed the emulator using the `npm run serve:seeded` command, the following command executes under the hood: `firebase emulators:exec --only auth,firestore,functions,storage --ui "npm run serve:seed && read -rd \"\""`. This spins up an emulator instance for the duration of the execution of the `"npm run serve:seed && read -rd \"\""` calls. `npm run serve:seed` executes the required functions to seed the emulator, and the `read -rd \"\"` then causes the emulator to continue running until the user cancels the operation.

However, when integrating the seeding functionality into the CI for ENGAGE, we need to be able to have a seeded instance of the emulator for the duration of the fastlane testing call. The `read -rd \"\"` won't work for the self-hosted runner, as there is no way to cancel the emulator without canceling the workflow. Instead, we can introduce an input to the build-and-test workflow that allows us to pass a custom command to execute right before the `fastlane test` call. This custom command will then stay in effect throughout the lifespan of the emulator, which will shut down after the fastlane process finishes.


## :gear: Release Notes 
- Added an input for the custom command called `customfirebaseemulatorcommand`
- Modified the execution of the fastlane command for the case where the `fastlanelane` argument is not empty, the `setupfirebaseemulator` argument is true, and the `firebaseemulatorimport` is empty.


Currently, the workflow executes the following command to run the fastlane tests if there is no firebase import provided: 
```shell
firebase emulators:exec 'fastlane ${{ inputs.fastlanelane }}'
``` 

Instead, we replace this with the following:
```shell
if [ -n "${{ inputs.customfirebaseemulatorcommand }}" ]; then
    firebase emulators:exec '${{ inputs.customfirebaseemulatorcommand }} && fastlane ${{ inputs.fastlanelane }}'
else
    firebase emulators:exec 'fastlane ${{ inputs.fastlanelane }}'
``` 

This allows the following emulator command to be run:
```shell
firebase emulators:exec 'npm run serve:seed && fastlane test'
``` 


## :books: Documentation
See description of `customfirebaseemulatorcommand` in `xcodebuild-or-fastland.yml`. 


## :white_check_mark: Testing
NA


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
