### PR TITLE
Add the ability to inject env variables through .env file creation

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -42,6 +42,11 @@ on:
         required: false
         type: string
         default: ''
+      workingDirectory:
+        description: 'The workingDirectory of the GitHub Action. Defaults to $GITHUB_WORKSPACE'
+        required: false
+        type: string
+        default: '.'
     secrets:
       GOOGLE_APPLICATION_CREDENTIALS_BASE64:
         description: |

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -49,6 +49,10 @@ on:
           You can lean more about how to generate the JSON at https://cloud.google.com/iam/docs/service-accounts-create.
           The service account must have the minimally required permissions documented at https://firebase.google.com/docs/projects/iam/permissions.
         required: true
+      ENV_FILE:
+        description: |
+          .env file that is injected in the build context before doing the firebase deployment.
+        required: false
 
 jobs:
   deployfirebase:
@@ -75,6 +79,12 @@ jobs:
           java-version: '17'
       - name: Install Firebase CLI Tools
         run: npm install -g firebase-tools
+      - name: Create .env file
+        env:
+          env-file: ${{ secrets.ENV_FILE }}
+        if: ${{ env.env-file != '' }}
+        run: |
+         echo "${{ env.env-file }}" > ${{ inputs.workingDirectory }}/.env
       - name: Run custom command
         if: ${{ inputs.customcommand != '' }}
         run: ${{ inputs.customcommand }}


### PR DESCRIPTION
# Add the ability to inject env variables through .env file creation

## :recycle: Current situation & Problem
https://github.com/StanfordBDHG/.github/pull/82 aims to achieve the same effect. We need to do it through `.env` file creation, because otherwise values aren't properly propagated to build process.


## :gear: Release Notes 
* Add the ability to inject env variables through .env file creation


## :white_check_mark: Testing
I updated created test deployment of Web-Frontend successfully with this branch. 


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
