### PR TITLE
Update the Simulator for the Xcode Documentation Building

### DIFF
--- a/.github/workflows/docc-github-pages.yml
+++ b/.github/workflows/docc-github-pages.yml
@@ -38,10 +38,10 @@ on:
       destination:
         description: |
           The destination parameter that should be passed to xcodebuild.
-          Defaults to the iOS simulator using an iPhone 15 Pro.
+          Defaults to the iOS simulator using an iPhone 16 Pro.
         required: false
         type: string
-        default: 'platform=iOS Simulator,name=iPhone 15 Pro'
+        default: 'platform=iOS Simulator,name=iPhone 16 Pro'
       dryrun:
         description: |
           Dry run deployment, only build documentation but do not publish


### PR DESCRIPTION
# Update the Simulator for the Xcode Documentation Building

## :recycle: Current situation & Problem
- Old iOS simulators are removed from newer runner images.

## :gear: Release Notes 
- Update the action to use an iPhone 16 Simulator

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
