### PR TITLE
Update to macOS 15-based Runners to Sync with Self-Hosted Runners

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -44,7 +44,7 @@ on:
           JSON-based collection of labels indicating which type of github runner should be chosen.
         type: string
         required: false
-        default: '["macos-14"]'
+        default: '["macos-15"]'
       sdk:
         description: |
           JSON-based collection of SDK for the exported framework. Defaults to all SDKs.

--- a/.github/workflows/create-and-upload-coverage-report.yml
+++ b/.github/workflows/create-and-upload-coverage-report.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   create-and-upload-coverage-report:
     name: Create and upload coverage report
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/docc-github-pages.yml
+++ b/.github/workflows/docc-github-pages.yml
@@ -22,7 +22,7 @@ on:
           JSON-based collection of labels indicating which type of github runner should be chosen
         required: false
         type: string
-        default: '["macos-14"]'
+        default: '["macos-15"]'
       xcodeversion:
         description: |
           The Xcode version used for the build

--- a/.github/workflows/periphery.yml
+++ b/.github/workflows/periphery.yml
@@ -20,7 +20,7 @@ on:
         description: 'JSON-based collection of labels indicating which type of github runner should be chosen'
         required: false
         type: string
-        default: '["macos-14"]'
+        default: '["macos-15"]'
       xcodeversion:
         description: 'The Xcode version used for the build'
         required: false

--- a/.github/workflows/xcframework.yml
+++ b/.github/workflows/xcframework.yml
@@ -45,7 +45,7 @@ on:
           JSON-based collection of labels indicating which type of github runner should be chosen.
         type: string
         required: false
-        default: '["macos-14"]'
+        default: '["macos-15"]'
       sdk:
         description: |
           JSON-based collection of SDK for the exported framework.

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -22,7 +22,7 @@ on:
           JSON-based collection of labels indicating which type of github runner should be chosen.
         required: false
         type: string
-        default: '["macos-14"]'
+        default: '["macos-15"]'
       xcodeversion:
         description: |
           The Xcode version used for the build.


### PR DESCRIPTION
# Update to macOS 15-based Runners to Sync with Self-Hosted Runners

## :gear: Release Notes 
- Update to macOS 15-based Runners to Sync with Self-Hosted Runners

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
