### PR TITLE
Support nested directories in "NPM Publish package"

### DIFF
--- a/.github/workflows/npm-publish-package.yml
+++ b/.github/workflows/npm-publish-package.yml
@@ -31,7 +31,7 @@ on:
     secrets:
       NPM_TOKEN:
         description: |
-          NPM toke
+          Used to perform authenticated operation against NPM registry
         required: true
 
 jobs:

--- a/.github/workflows/npm-publish-package.yml
+++ b/.github/workflows/npm-publish-package.yml
@@ -23,6 +23,12 @@ on:
         required: false
         type: string
         default: ''
+      workingDirectory:
+        description: |
+          Set working directory if your package is not in the root.
+        required: false
+        type: string
+        default: '.'
       packageVersion:
         description: |
           Released packaged version
@@ -38,6 +44,9 @@ jobs:
   publish-package:
     name: Publish Package
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.workingDirectory }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/npm-publish-package.yml
+++ b/.github/workflows/npm-publish-package.yml
@@ -17,6 +17,12 @@ on:
         required: false
         type: string
         default: '22.x'
+      cacheDependencyPath:
+        description: |
+          Node cache dependency path. It's required only if package-lock.json is not in the root.
+        required: false
+        type: string
+        default: ''
       packageVersion:
         description: |
           Released packaged version
@@ -36,6 +42,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
+          cache-dependency-path: ${{ inputs.cacheDependencyPath }}
           node-version: ${{ inputs.nodeVersion }}
           registry-url: 'https://registry.npmjs.org'
       - name: Clean Install


### PR DESCRIPTION
# Support nested directories in "NPM Publish package"

## :recycle: Current situation & Problem
If NPM package is nested deeply into repository, there is a need to specify working directory and `cache-dependency-path`. 


## :gear: Release Notes 
* Add cache dependency path param to "NPM Publish package"
* Improve NPM token description
* Add working directory param

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
