### PR TITLE
Add localhost to ignored Linkspector URLs

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -31,6 +31,7 @@ jobs:
             echo "useGitIgnore: true" >> $CONFIG_FILE
             echo "ignorePatterns:" >> $CONFIG_FILE
             echo "  - pattern: '^doc:.*$'" >> $CONFIG_FILE
+            echo "  - pattern: '^http://localhost.*$'" >> $CONFIG_FILE
             echo "replacementPatterns:" >> $CONFIG_FILE
             echo "  - pattern: '(.*)#gh-dark-mode-only'" >> $CONFIG_FILE
             echo "    replacement: '\$1'" >> $CONFIG_FILE


### PR DESCRIPTION
# Add localhost to ignored Linkspector URLs

## :recycle: Current situation & Problem
`localhost` URLs are checked by Linkspector. Example of failing action: https://github.com/StanfordBDHG/ENGAGE-HF-Web-Frontend/pull/116/checks?check_run_id=36385190565

## :gear: Release Notes 
* Add localhost to ignored Linkspector URLs

## :white_check_mark: Testing
Tested here:
https://github.com/StanfordBDHG/ENGAGE-HF-Web-Frontend/pull/117/checks?check_run_id=36434336444

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
