### PR TITLE
Add `OPENAI_API_KEY` as a New Environment Variable

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -211,6 +211,11 @@ on:
           The Base64 version of the private key JSON file to boot up the firebase emulator.
           Only needed if cloud functions are used to fully support the execution of cloud functions in the emulator.
         required: false
+      OPENAI_API_KEY:
+        description: |
+          The OpenAI API key used for accessing OpenAI services within a workflow.
+          Required when using OpenAI-powered features in your application.
+        required: false  
 
 jobs:
   build_and_test:
@@ -407,6 +412,7 @@ jobs:
           APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           GOOGLE_APPLICATION_CREDENTIALS_BASE64: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       - name: Perform CodeQL Analysis
         if: ${{ !env.selfhosted && inputs.codeql }}
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
# Add `OPENAI_API_KEY` as a New Environment Variable

## :gear: Release Notes 
Added support for `OPENAI_API_KEY` as a new environment variable to enable OpenAI API integration without asking the user to provide a key. This key is now required and passed during the build process before shipping to TestFlight.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
