### PR TITLE
periphery action: add flag to control `--strict` mode

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 *Link any open issues or pull requests (PRs) related to this PR. Please ensure that all non-trivial PRs are first tracked and discussed in an existing GitHub issue or discussion.*
 
 
-## :gear: Release Notes 
+## :gear: Release Notes
 *Add a bullet point list summary of the feature and possible migration guides if this is a breaking change so this section can be added to the release notes.*
 *Include code snippets that provide examples of the feature implemented or links to the documentation if it appends or changes the public interface.*
 
@@ -19,7 +19,6 @@
 *This section describes important information about the tests and why some elements might not be testable.*
 
 
-### Code of Conduct & Contributing Guidelines 
-
-By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
+### Code of Conduct & Contributing Guidelines
+By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
 - [ ] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

--- a/.github/workflows/periphery.yml
+++ b/.github/workflows/periphery.yml
@@ -26,6 +26,11 @@ on:
         required: false
         type: string
         default: 'latest-stable'
+      strict:
+        description: 'Whether perhipery should run in --strict mode'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -54,7 +59,7 @@ jobs:
         run: brew install periphery
       - name: Run periphery
         run: |
-          periphery scan --relative-results --format github-actions --strict -- -skipPackagePluginValidation -skipMacroValidation
+          periphery scan --relative-results --format github-actions ${{ inputs.strict && '--strict' || '' }} -- -skipPackagePluginValidation -skipMacroValidation
       - name: Cleanup periphery
         if: always()
         run: rm -rf ~/Library/Caches/com.github.peripheryapp

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,4 +13,4 @@ SPDX-License-Identifier: MIT
 Please report security vulnerabilities using the GitHub [privately reporting a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/best-practices-for-writing-repository-security-advisories) functionality.
 We highly value your input and will get back to you as soon as possible. Please include steps to reproduce, context, and any further information that makes identifying and resolving the vulnerability as quickly as possible.
 
-See the [The CERT Guide to Coordinated Vulnerability Disclosure](https://vuls.cert.org/confluence/display/CVD/The+CERT+Guide+to+Coordinated+Vulnerability+Disclosure) for additional background information about the coordinated vulnerability disclosure process.
+See [The CERT Guide to Coordinated Vulnerability Disclosure](https://vuls.cert.org/CERT-Guide-to-CVD/) for additional background information about the coordinated vulnerability disclosure process.


### PR DESCRIPTION
# periphery action: add flag to control `--strict` mode

## :recycle: Current situation & Problem
The periphery action currently always runs in `--strict` mode, which turns all warnings into errors (or, rather, if any warnings are encountered, the command will fail).
This behaviour is desired in the vast majority of cases, but there are exceptions.
(eg, if you're implementing a soon-to-be-used-but-currently-still-unused component, it would be valid to temporarily have technically unused code in the codebase.)
This flag allows for supporting this.


## :gear: Release Notes 
n/a

## :books: Documentation
n/a

## :white_check_mark: Testing
n/a

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
