### PR TITLE
Fix Linkspector RegEx Bug

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -43,6 +43,6 @@ jobs:
           echo "Contents of $CONFIG_FILE:"
           cat $CONFIG_FILE
       - name: Linkspector
-        uses: umbrelladocs/action-linkspector@v1
+        uses: umbrelladocs/action-linkspector@v1.2.5
         with:
           filter_mode: nofilter

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ SPDX-License-Identifier: MIT
 
 -->
 
+http://localhost
+
 # Stanford Biodesign Digital Health Group
 
 This repository serves as a collection of default community health files, GitHub Action workflows, templates, and information for the Stanford Biodesign Digital Health Group organization.
 
-
 ## GitHub Actions
 
 This repository contains several GitHub Actions that automate and simplify the process of contributing to Stanford Biodesign Digital Health Group-related projects.
-
 
 ### Test Using Xcodebuild or Run Fastlane
 
@@ -66,9 +66,9 @@ Ensure that all Swift files conform to the defined style guide.
 You can learn more about the arguments in the [`swiftlint.yml` GitHub Action file](https://github.com/StanfordBDHG/.github/blob/main/.github/workflows/swiftlint.yml).
 
 ```yml
-  swiftlint:
-    name: SwiftLint
-    uses: StanfordBDHG/.github/.github/workflows/swiftlint.yml@v2
+swiftlint:
+  name: SwiftLint
+  uses: StanfordBDHG/.github/.github/workflows/swiftlint.yml@v2
 ```
 
 ### Action Tag Release
@@ -127,11 +127,9 @@ jobs:
 
 The [ContinousIntegration](https://github.com/StanfordBDHG/ContinousIntegration) repository contains the setup and information about our self-hosted GitHub Action runners that is fitting the GitHub Actions found in this repository.
 
-
 ## Our Research
 
 For more information, check out our website at [biodesigndigitalhealth.stanford.edu](https://biodesigndigitalhealth.stanford.edu).
 
 ![Stanford Mussallem Center for Biodesign Logo](https://raw.githubusercontent.com/StanfordBDHG/.github/main/assets/biodesign-footer-light.png#gh-light-mode-only)
 ![Stanford Mussallem Center for Biodesign Logo](https://raw.githubusercontent.com/StanfordBDHG/.github/main/assets/biodesign-footer-dark.png#gh-dark-mode-only)
-

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ SPDX-License-Identifier: MIT
 
 -->
 
-http://localhost
-
 # Stanford Biodesign Digital Health Group
 
 This repository serves as a collection of default community health files, GitHub Action workflows, templates, and information for the Stanford Biodesign Digital Health Group organization.
 
+
 ## GitHub Actions
 
 This repository contains several GitHub Actions that automate and simplify the process of contributing to Stanford Biodesign Digital Health Group-related projects.
+
 
 ### Test Using Xcodebuild or Run Fastlane
 
@@ -66,9 +66,9 @@ Ensure that all Swift files conform to the defined style guide.
 You can learn more about the arguments in the [`swiftlint.yml` GitHub Action file](https://github.com/StanfordBDHG/.github/blob/main/.github/workflows/swiftlint.yml).
 
 ```yml
-swiftlint:
-  name: SwiftLint
-  uses: StanfordBDHG/.github/.github/workflows/swiftlint.yml@v2
+  swiftlint:
+    name: SwiftLint
+    uses: StanfordBDHG/.github/.github/workflows/swiftlint.yml@v2
 ```
 
 ### Action Tag Release
@@ -127,9 +127,11 @@ jobs:
 
 The [ContinousIntegration](https://github.com/StanfordBDHG/ContinousIntegration) repository contains the setup and information about our self-hosted GitHub Action runners that is fitting the GitHub Actions found in this repository.
 
+
 ## Our Research
 
 For more information, check out our website at [biodesigndigitalhealth.stanford.edu](https://biodesigndigitalhealth.stanford.edu).
 
 ![Stanford Mussallem Center for Biodesign Logo](https://raw.githubusercontent.com/StanfordBDHG/.github/main/assets/biodesign-footer-light.png#gh-light-mode-only)
 ![Stanford Mussallem Center for Biodesign Logo](https://raw.githubusercontent.com/StanfordBDHG/.github/main/assets/biodesign-footer-dark.png#gh-dark-mode-only)
+


### PR DESCRIPTION
# Fix Linkspector RegEx Bug

## :recycle: Current situation & Problem
With a recent update in linkspector, it no longer accepts RegEx for ignore and replacement patterns.

To unblock our PRs, I am hence changing the default configuration.

The issue has been reported [here](https://github.com/UmbrellaDocs/linkspector/issues/109)


## :books: Documentation
* Hardcode the version to the last working on, i.e., 1.2.5


## :white_check_mark: Testing

|Before|After|
|--|--|
| After adding "localhost" to the README in https://github.com/StanfordBDHG/.github/pull/106/commits/ec703252e30dd6001df8c6db3cfb923265edb460 <img width="1095" alt="image" src="https://github.com/user-attachments/assets/435a00c2-5c50-4182-864c-14cef8cb1ebd"/> |  <img width="1101" alt="image" src="https://github.com/user-attachments/assets/34e55c30-277b-48cd-85bd-b160aa503ddd" /> |




### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
