### PR TITLE
Rollback to Linkspector Version V1

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -43,6 +43,6 @@ jobs:
           echo "Contents of $CONFIG_FILE:"
           cat $CONFIG_FILE
       - name: Linkspector
-        uses: umbrelladocs/action-linkspector@v1.2.5
+        uses: umbrelladocs/action-linkspector@v1
         with:
           filter_mode: nofilter


### PR DESCRIPTION
Stacked PRs:
 * __->__#107


--- --- ---

# Rollback to Linkspector Version V1

## :recycle: Current situation & Problem
With the recent [fix of Linkspector](https://github.com/UmbrellaDocs/linkspector/commit/73a9a304b5b4ff165b090c69247ef28a892aa1c6), the the changes from #106 are no longer needed.

## :books: Documentation
* Rollback the Linkspector version to V1

## :white_check_mark: Testing
See CI

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).