### PR TITLE
codecov@v5

### DIFF
--- a/.github/workflows/create-and-upload-coverage-report.yml
+++ b/.github/workflows/create-and-upload-coverage-report.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
             xcrun xcresulttool merge ${{ inputs.coveragereports }} --output-path CodeCoverage.xcresult
             rm -rf ${{ inputs.coveragereports }}
-      - uses: lukaskollmer/xccov2lcov@test-gh-action
+      - uses: lukaskollmer/xccov2lcov@develop
         with:
           xcresult: CodeCoverage.xcresult
       - name: Upload coverage to Codecov

--- a/.github/workflows/create-and-upload-coverage-report.yml
+++ b/.github/workflows/create-and-upload-coverage-report.yml
@@ -46,7 +46,7 @@ jobs:
             xcrun xcresulttool merge ${{ inputs.coveragereports }} --output-path CodeCoverage.xcresult
             rm -rf ${{ inputs.coveragereports }}
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true
           token: ${{ secrets.token }}

--- a/.github/workflows/create-and-upload-coverage-report.yml
+++ b/.github/workflows/create-and-upload-coverage-report.yml
@@ -45,6 +45,9 @@ jobs:
         run: |
             xcrun xcresulttool merge ${{ inputs.coveragereports }} --output-path CodeCoverage.xcresult
             rm -rf ${{ inputs.coveragereports }}
+      - uses: lukaskollmer/xccov2lcov@test-gh-action
+        with:
+          xcresult: CodeCoverage.xcresult
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/create-and-upload-coverage-report.yml
+++ b/.github/workflows/create-and-upload-coverage-report.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
             xcrun xcresulttool merge ${{ inputs.coveragereports }} --output-path CodeCoverage.xcresult
             rm -rf ${{ inputs.coveragereports }}
-      - uses: stanfordbdhg/xccov2lcov@main
+      - uses: stanfordbdhg/xccov2lcov@v1
         with:
           xcresult: CodeCoverage.xcresult
       - name: Upload coverage to Codecov

--- a/.github/workflows/create-and-upload-coverage-report.yml
+++ b/.github/workflows/create-and-upload-coverage-report.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
             xcrun xcresulttool merge ${{ inputs.coveragereports }} --output-path CodeCoverage.xcresult
             rm -rf ${{ inputs.coveragereports }}
-      - uses: lukaskollmer/xccov2lcov@develop
+      - uses: stanfordbdhg/xccov2lcov@main
         with:
           xcresult: CodeCoverage.xcresult
       - name: Upload coverage to Codecov

--- a/.github/workflows/create-and-upload-coverage-report.yml
+++ b/.github/workflows/create-and-upload-coverage-report.yml
@@ -53,5 +53,3 @@ jobs:
         with:
           fail_ci_if_error: true
           token: ${{ secrets.token }}
-          xcode: true
-          xcode_archive_path: CodeCoverage.xcresult

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -18,4 +18,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: REUSE Compliance Check
-        uses: fsfe/reuse-action@v5
+        uses: fsfe/reuse-action@v1

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -18,4 +18,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: REUSE Compliance Check
-        uses: fsfe/reuse-action@v1
+        uses: fsfe/reuse-action@v5


### PR DESCRIPTION
# codecov@v5

## :recycle: Current situation & Problem
We're currently using v3 of the codecov action, which is sometimes causing issues, e.g. random timeouts, missing coverage uploads, or problems with new repositories.
Upgrading to v5 will hopefully increase stability here.
Since, somewhere between v3 and v5, codecov seems to have removed native support for xcresult-bundle-based coverage uploads, we need to add an additional step to export the xcresult bundle's coverage data into an `lcov` file.

## :gear: Release Notes
- upgraded codecov to v5

## :books: Documentation
n/a (if this works as intended, it should not require any changes in other repos that are using the `create-and-upload-coverage-report` workflow.

## :white_check_mark: Testing
n/a


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
