### PR TITLE
update reuse action from v1 to v5

### DIFF
--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -18,4 +18,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: REUSE Compliance Check
-        uses: fsfe/reuse-action@v1
+        uses: fsfe/reuse-action@v5


### PR DESCRIPTION
# update reuse action from v1 to v5

## :recycle: Current situation & Problem
We're using a very outdated version of the reuse action. This PR updates this workflow step from v1 to v5.
I did some testing with the [StanfordBDHG/xccov2lcov](https://github.com/StanfordBDHG/xccov2lcov) repo, and this should work without requiring any additional changes.

## :gear: Release Notes
- Upgrade REUSE check action from v1 to v5.

## :books: Documentation
n/a

## :white_check_mark: Testing
n/a

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
