### PR TITLE
xcodebuild-or-fastlane: add a "check available simulators" step

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -236,6 +236,7 @@ jobs:
             swift --version
             echo "env.selfhosted: ${{ env.selfhosted }}"
             echo "environment: ${{ inputs.environment }}"
+            xcrun simctl list
       - name: Install xcbeautify
         if: ${{ !env.selfhosted && inputs.scheme != '' }}
         run: brew install xcbeautify
@@ -322,6 +323,9 @@ jobs:
         if: ${{ inputs.setupSimulators && inputs.destination != '' }}
         run: |
           echo "::warning::Script-based simulator setup to disable Password Autofill was removed and is deprecated. Please stop using this option."
+      - name: Check available Simulators
+        run: |
+          xcrun xcodebuild -scheme ${{ inputs.scheme }} -showdestinations
       - name: Run custom command
         if: ${{ inputs.customcommand != '' }}
         run: ${{ inputs.customcommand }}


### PR DESCRIPTION
# xcodebuild-or-fastlane: add a "check available simulators" step

## :recycle: Current situation & Problem
This PR extends the "Check Environment" step to add a `xcrun simctl list` call, and adds a new "Check Available Simulators" step that runs `xcrun xcodebuild -showdestinations`.
The reason why this might be useful is that some (many) of the different repos' build-and-test workflows specify simulators by name, but these simulators aren't necessarily always available (the versions and device names will change with Xcode updates, e.g.) and in some cases are sometimes randomly missing. These changes will hopefully give a little more insight into the actually existing/available simulators.

## :gear: Release Notes
- added a "check available simulators" step


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a (though this will hopefully make testing a little easier)

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
