### PR TITLE
bring back the xcodebuild-or-fastlane "check available simulators" step

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -324,6 +324,7 @@ jobs:
         run: |
           echo "::warning::Script-based simulator setup to disable Password Autofill was removed and is deprecated. Please stop using this option."
       - name: Check available Simulators
+        if: ${{ inputs.scheme != '' }}
         run: |
           xcrun xcodebuild -scheme ${{ inputs.scheme }} -showdestinations
       - name: Run custom command

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -236,6 +236,7 @@ jobs:
             swift --version
             echo "env.selfhosted: ${{ env.selfhosted }}"
             echo "environment: ${{ inputs.environment }}"
+            xcrun simctl list
       - name: Install xcbeautify
         if: ${{ !env.selfhosted && inputs.scheme != '' }}
         run: brew install xcbeautify
@@ -322,6 +323,9 @@ jobs:
         if: ${{ inputs.setupSimulators && inputs.destination != '' }}
         run: |
           echo "::warning::Script-based simulator setup to disable Password Autofill was removed and is deprecated. Please stop using this option."
+      - name: Check available Simulators
+        run: |
+          xcrun xcodebuild -scheme ${{ inputs.scheme }} -showdestinations
       - name: Run custom command
         if: ${{ inputs.customcommand != '' }}
         run: ${{ inputs.customcommand }}


### PR DESCRIPTION
# bring back the xcodebuild-or-fastlane "check available simulators" step

## :recycle: Current situation & Problem
Second attempt at #110, which has since been reverted, this time with an extra check to properly handle empty `inputs.scheme` values.

thanks to @jdisho for pointing this out

## :gear: Release Notes
- added steps to check the simulators available in the environment

## :books: Documentation
n/a

## :white_check_mark: Testing
n/a

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
