### PR TITLE
Add packageTag input to npm-publish-package

### DIFF
--- a/.github/workflows/npm-publish-package.yml
+++ b/.github/workflows/npm-publish-package.yml
@@ -31,13 +31,19 @@ on:
         default: '.'
       packageVersion:
         description: |
-          Released packaged version
+          Released package version.
         required: true
         type: string
+      packageTag:
+        description: |
+          Released package tag.
+        required: false
+        type: string
+        default: "latest"
     secrets:
       NPM_TOKEN:
         description: |
-          Used to perform authenticated operation against NPM registry
+          Used to perform authenticated operation against NPM registry.
         required: true
 
 jobs:
@@ -57,7 +63,7 @@ jobs:
       - name: Clean Install
         run: npm ci
       - name: Set version
-        run: npm version --no-git-tag-version ${{ inputs.packageVersion }}
+        run: npm version --no-git-tag-version --tag ${{ inputs.packageTag }} ${{ inputs.packageVersion }}
       - name: Build
         run: npm run build
       - name: Publish


### PR DESCRIPTION
# Add packageTag input to npm-publish-package

## :recycle: Current situation & Problem
`--tag`  parameter allows creating separate release canals for packages. For example, if we want to publish release candidate or experimental release, we cannot omit `--tag` parameter, because this version would become a latest version of the package. If `packageTag` is not provided, it defaults to `"latest"` which is a default for `npm publish`.


## :gear: Release Notes
* Add packageTag input to npm-publish-package


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
