### PR TITLE
add `testplan` option

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -381,19 +381,20 @@ jobs:
             fi
 
             if [ -n "${{ inputs.testplan }}" ]; then
-                TESTPLAN="-testPlan '${{ inputs.testplan }}'"
+                TESTPLAN=(-testPlan "${{ inputs.testplan }}")
             else
-                TESTPLAN=""
+                TESTPLAN=()
             fi
 
             echo "TESTPLAN: <<$TESTPLAN>>"
+            echo "TESTPLAN: <<$TESTPLAN[@]>>"
 
             set -o pipefail \
             && xcodebuild -verbose $XCODECOMMAND \
               -scheme "${{ inputs.scheme }}" \
               -configuration "${{ inputs.buildConfig }}" \
               -destination "${{ inputs.destination }}" \
-              $TESTPLAN \
+              "$TESTPLAN[@]" \
               $CODECOVERAGEFLAG \
               -derivedDataPath ".derivedData" \
               -resultBundlePath "$RESULTBUNDLE" \

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -353,8 +353,6 @@ jobs:
       - name: Build and test (xcodebuild)
         if: ${{ inputs.scheme != '' }}
         run: |
-            set -x
-
             if ${{ inputs.test }}; then
                 XCODECOMMAND="test"
                 CODECOVERAGEFLAG="-enableCodeCoverage YES"
@@ -386,9 +384,6 @@ jobs:
                 TESTPLAN=()
             fi
 
-            echo "TESTPLAN: <<${TESTPLAN}>>"
-            echo "TESTPLAN: <<${TESTPLAN[@]}>>"
-
             set -o pipefail \
             && xcodebuild -verbose $XCODECOMMAND \
               -scheme "${{ inputs.scheme }}" \
@@ -402,7 +397,8 @@ jobs:
               CODE_SIGN_IDENTITY="" \
               OTHER_SWIFT_FLAGS="\$(inherited) $ENABLE_TESTING_FLAG $SWIFT_VERSION_FLAG" \
               -skipPackagePluginValidation \
-              -skipMacroValidation
+              -skipMacroValidation \
+            | xcbeautify
       - name: Fastlane
         if: ${{ inputs.fastlanelane != '' }}
         run: |

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -379,7 +379,7 @@ jobs:
             fi
 
             if [ -n "${{ inputs.testplan }}" ]; then
-                TESTPLAN="-testPlan '${{ inputs.testplan }}'"
+                TESTPLAN="-testPlan \"${{ inputs.testplan }}\""
             else
                 TESTPLAN=""
             fi

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -386,15 +386,15 @@ jobs:
                 TESTPLAN=()
             fi
 
-            echo "TESTPLAN: <<$TESTPLAN>>"
-            echo "TESTPLAN: <<$TESTPLAN[@]>>"
+            echo "TESTPLAN: <<${TESTPLAN}>>"
+            echo "TESTPLAN: <<${TESTPLAN[@]}>>"
 
             set -o pipefail \
             && xcodebuild -verbose $XCODECOMMAND \
               -scheme "${{ inputs.scheme }}" \
               -configuration "${{ inputs.buildConfig }}" \
               -destination "${{ inputs.destination }}" \
-              "$TESTPLAN[@]" \
+              "${TESTPLAN[@]}" \
               $CODECOVERAGEFLAG \
               -derivedDataPath ".derivedData" \
               -resultBundlePath "$RESULTBUNDLE" \

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -353,6 +353,8 @@ jobs:
       - name: Build and test (xcodebuild)
         if: ${{ inputs.scheme != '' }}
         run: |
+            set -x
+
             if ${{ inputs.test }}; then
                 XCODECOMMAND="test"
                 CODECOVERAGEFLAG="-enableCodeCoverage YES"
@@ -385,7 +387,7 @@ jobs:
             fi
 
             set -o pipefail \
-            && xcodebuild $XCODECOMMAND \
+            && xcodebuild -verbose $XCODECOMMAND \
               -scheme "${{ inputs.scheme }}" \
               -configuration "${{ inputs.buildConfig }}" \
               -destination "${{ inputs.destination }}" \
@@ -397,8 +399,7 @@ jobs:
               CODE_SIGN_IDENTITY="" \
               OTHER_SWIFT_FLAGS="\$(inherited) $ENABLE_TESTING_FLAG $SWIFT_VERSION_FLAG" \
               -skipPackagePluginValidation \
-              -skipMacroValidation \
-            | xcbeautify
+              -skipMacroValidation
       - name: Fastlane
         if: ${{ inputs.fastlanelane != '' }}
         run: |

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -77,6 +77,12 @@ on:
         required: false
         type: boolean
         default: true
+      testplan:
+        description: |
+          The Test Plan that should be run.
+        required: false
+        type: string
+        default: ''
       fastlanelane:
         description: |
           The lane of the fastlane command.
@@ -372,11 +378,18 @@ jobs:
                 SWIFT_VERSION_FLAG=""
             fi
 
+            if [ -n "${{ inputs.testplan }}" ]; then
+                TESTPLAN="-testPlan ${{ inputs.testplan }}"
+            else
+                TESTPLAN=""
+            fi
+
             set -o pipefail \
             && xcodebuild $XCODECOMMAND \
               -scheme "${{ inputs.scheme }}" \
               -configuration "${{ inputs.buildConfig }}" \
               -destination "${{ inputs.destination }}" \
+              $TESTPLAN \
               $CODECOVERAGEFLAG \
               -derivedDataPath ".derivedData" \
               -resultBundlePath "$RESULTBUNDLE" \

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -381,7 +381,7 @@ jobs:
             fi
 
             if [ -n "${{ inputs.testplan }}" ]; then
-                TESTPLAN='-testPlan \'${{ inputs.testplan }}\''
+                TESTPLAN="-testPlan '${{ inputs.testplan }}'"
             else
                 TESTPLAN=""
             fi

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -385,7 +385,7 @@ jobs:
             fi
 
             set -o pipefail \
-            && xcodebuild -verbose $XCODECOMMAND \
+            && xcodebuild $XCODECOMMAND \
               -scheme "${{ inputs.scheme }}" \
               -configuration "${{ inputs.buildConfig }}" \
               -destination "${{ inputs.destination }}" \

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -379,7 +379,7 @@ jobs:
             fi
 
             if [ -n "${{ inputs.testplan }}" ]; then
-                TESTPLAN="-testPlan ${{ inputs.testplan }}"
+                TESTPLAN="-testPlan '${{ inputs.testplan }}'"
             else
                 TESTPLAN=""
             fi

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -386,6 +386,8 @@ jobs:
                 TESTPLAN=""
             fi
 
+            echo "TESTPLAN: <<$TESTPLAN>>"
+
             set -o pipefail \
             && xcodebuild -verbose $XCODECOMMAND \
               -scheme "${{ inputs.scheme }}" \

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -381,7 +381,7 @@ jobs:
             fi
 
             if [ -n "${{ inputs.testplan }}" ]; then
-                TESTPLAN="-testPlan \"${{ inputs.testplan }}\""
+                TESTPLAN='-testPlan \'${{ inputs.testplan }}\''
             else
                 TESTPLAN=""
             fi


### PR DESCRIPTION
# add `testplan` option

## :recycle: Current situation & Problem
We currently assume that a repo/project being tested using the `xcodebuild-or-fastlane` action has only a single test plan, and that xcodebuild will correctly identify and auto-select that on its own (which is indeed what's happening).
But there is no support for having multiple test plans, and selecting which of them should be run.

This PR adds just that: we now have a new (optional) `testplan` input, which can be used to instruct xcodebuild to run only that test plan (i.e., only the tests belonging to that test plan).

The immediate use case here is the MyHeartCounts app, which uses separate test plans for its (non-UI) unit tests and its UI tests, and for which we want both sets of tests to run completelt separate from each other.


## :gear: Release Notes
- added a new optional `testplan` input to the `xcodebuild-or-fastlane` action


## :books: Documentation
the new input is documented


## :white_check_mark: Testing
n/a


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
