### PR TITLE
use package tag instead of package.json

### DIFF
--- a/.github/workflows/npm-publish-package.yml
+++ b/.github/workflows/npm-publish-package.yml
@@ -40,9 +40,9 @@ on:
         required: false
         type: string
         default: "latest"
-      workspace:
+      workspaces:
         description: |
-          Set to true to enable npm workspace publishing.
+          Set to true to enable npm workspaces publishing.
         required: false
         type: boolean
         default: false
@@ -69,15 +69,22 @@ jobs:
       - name: Clean Install
         run: npm ci
       - name: Set version
-        run: npm version --no-git-tag-version --tag ${{ inputs.packageTag }} ${{ inputs.packageVersion }}
+        run: |
+          if [ "${{ inputs.workspaces }}" = "true" ]; then
+            # Update version in all workspace packages
+            npm version --no-git-tag-version --workspaces ${{ inputs.packageVersion }}
+          else
+            # Update version in root package only
+            npm version --no-git-tag-version --tag ${{ inputs.packageTag }} ${{ inputs.packageVersion }}
+          fi
       - name: Build
         run: npm run build
       - name: Publish
         run: |
-          if [ "${{ inputs.workspace }}" = "true" ]; then
-            npm publish --workspaces --provenance --access public
+          if [ "${{ inputs.workspaces }}" = "true" ]; then
+            npm publish --workspaces --provenance --access public --tag ${{ inputs.packageTag }}
           else
-            npm publish --provenance --access public
+            npm publish --provenance --access public --tag ${{ inputs.packageTag }}
           fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
# use package tag instead of package.json

## :recycle: Current situation & Problem
We want to use the release tag version and overwrite the package.json when using the workspaces feature.

## :gear: Release Notes
N/A

## :books: Documentation
N/A


## :white_check_mark: Testing
N/A

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
