### PR TITLE
xcodebuild-or-fastlane: add option to remove certain entitlements

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -350,7 +350,7 @@ jobs:
               echo 'Missing entitlements_file' workflow input
               exit 1
           fi
-          ENTITLEMENTS_FILE="${TARGET_TEMP_DIR}/${FULL_PRODUCT_NAME}.xcent"
+          ENTITLEMENTS_FILE="${{ inputs.entitlements_file }}"
           echo "Entitlements file before potential adjustments: (${ENTITLEMENTS_FILE})"
           cat "${ENTITLEMENTS_FILE}"
           remove_entitlement() {

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -349,8 +349,8 @@ jobs:
         if: ${{ inputs.remove_entitlements != '' }}
         run: |
           if [ -z "${{ inputs.entitlements_file }}" ]; then
-              echo Missing 'entitlements_file' workflow input
-              exit 1
+            echo Missing 'entitlements_file' workflow input
+            exit 1
           fi
           ENTITLEMENTS_FILE="${{ inputs.entitlements_file }}"
           remove_entitlement() {

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -349,7 +349,7 @@ jobs:
         if: ${{ inputs.remove_entitlements != '' }}
         run: |
           if [ -z "${{ inputs.entitlements_file }}" ]; then
-              echo 'Missing entitlements_file' workflow input
+              echo Missing 'entitlements_file' workflow input
               exit 1
           fi
           ENTITLEMENTS_FILE="${{ inputs.entitlements_file }}"

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -168,11 +168,13 @@ on:
       entitlements_file:
         description: |
           Path of the project's Entitlements file, relative to the repository root.
+          Required if `remove_entitlements` is specified.
         required: false
         type: string
       remove_entitlements:
         description: |
           Semicolon-separated list of entitlements that should be removed.
+          Note: periods in an entitlement name are interpreted as path separators; you probably need to escape them if they are part of the entitlement's name.
         required: false
         type: string
     secrets:

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -165,6 +165,16 @@ on:
         required: false
         type: boolean
         default: false
+      entitlements_file:
+        description: |
+          Path of the project's Entitlements file, relative to the repository root.
+        required: false
+        type: string
+      remove_entitlements:
+        description: |
+          Semicolon-separated list of entitlements that should be removed.
+        required: false
+        type: string
     secrets:
       BUILD_CERTIFICATE_BASE64:
         description: |
@@ -333,6 +343,23 @@ jobs:
         if: ${{ inputs.scheme != '' }}
         run: |
           xcrun xcodebuild -scheme ${{ inputs.scheme }} -showdestinations
+      - name: "Adjust Entitlements"
+        if: ${{ inputs.remove_entitlements != '' }}
+        run: |
+          if [ -z ${{ inputs.entitlements_file }} ]; then
+              echo 'Missing entitlements_file' workflow input
+              exit 1
+          fi
+          ENTITLEMENTS_FILE="${TARGET_TEMP_DIR}/${FULL_PRODUCT_NAME}.xcent"
+          echo "Entitlements file before potential adjustments: (${ENTITLEMENTS_FILE})"
+          cat "${ENTITLEMENTS_FILE}"
+          remove_entitlement() {
+            plutil -remove "$1" "${ENTITLEMENTS_FILE}"
+          }
+          IFS=';' read -ra NAMES <<< "${{ inputs.remove_entitlements }}"
+          for name in "${NAMES[@]}"; do
+            remove_entitlement "$name"
+          done
       - name: Run custom command
         if: ${{ inputs.customcommand != '' }}
         run: ${{ inputs.customcommand }}

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -346,14 +346,13 @@ jobs:
       - name: "Adjust Entitlements"
         if: ${{ inputs.remove_entitlements != '' }}
         run: |
-          if [ -z ${{ inputs.entitlements_file }} ]; then
+          if [ -z "${{ inputs.entitlements_file }}" ]; then
               echo 'Missing entitlements_file' workflow input
               exit 1
           fi
           ENTITLEMENTS_FILE="${{ inputs.entitlements_file }}"
-          echo "Entitlements file before potential adjustments: (${ENTITLEMENTS_FILE})"
-          cat "${ENTITLEMENTS_FILE}"
           remove_entitlement() {
+            echo "Removing '$1'" from ${ENTITLEMENTS_FILE}"
             plutil -remove "$1" "${ENTITLEMENTS_FILE}"
           }
           IFS=';' read -ra NAMES <<< "${{ inputs.remove_entitlements }}"

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -354,7 +354,7 @@ jobs:
           fi
           ENTITLEMENTS_FILE="${{ inputs.entitlements_file }}"
           remove_entitlement() {
-            echo "Removing '$1'" from ${ENTITLEMENTS_FILE}"
+            echo "Removing '$1' from ${ENTITLEMENTS_FILE}"
             plutil -remove "$1" "${ENTITLEMENTS_FILE}"
           }
           IFS=';' read -ra NAMES <<< "${{ inputs.remove_entitlements }}"


### PR DESCRIPTION
# xcodebuild-or-fastlane: add option to remove certain entitlements

## :recycle: Current situation & Problem
problem: you sometimes need to (conditionally) strip some entitlements from an app before compiling and deploying it.
this could be e.g. bc you have a multiplatform (macCatalyst) app where only a subset of the iOS entitlements are supported when compiling the codebase for macOS.
our current use case is different: we need to strip the SensorKit entitlement from MHC since we don't yet have a SensorKit-enabled iTunes Connect provisioning profile.

## :gear: Release Notes
- added `entitlements_file` and `remove_entitlements` options to the `xcodebuild-or-fastlane` workflow.


## :books: Documentation
the new options are documented


## :white_check_mark: Testing
n/a

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
