### PR TITLE
mac catalyst support

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -363,7 +363,7 @@ jobs:
             if [ -z "${{ inputs.resultBundle }}" ]; then
                 RESULTBUNDLE=${{ inputs.scheme }}.xcresult
             else
-                RESULTBUNDLE=${{ inputs.resultBundle }}
+                RESULTBUNDLE="${{ inputs.resultBundle }}"
             fi
 
             if [ "${{ inputs.buildConfig }}" = "Release" ]; then

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -361,7 +361,7 @@ jobs:
             fi
 
             if [ -z "${{ inputs.resultBundle }}" ]; then
-                RESULTBUNDLE=${{ inputs.scheme }}.xcresult
+                RESULTBUNDLE="${{ inputs.scheme }}.xcresult"
             else
                 RESULTBUNDLE="${{ inputs.resultBundle }}"
             fi


### PR DESCRIPTION
# mac catalyst support

## :recycle: Current situation & Problem
the `RESULTBUNDLE` shell variable's value currently isn't quoted, leading to issues when expanding it in the `xcodebuild` command.
this hasn't been a problem so far since the result bundle names have, until now, never contained spaces.
adding mac catalyst support via the new matrix-based setup, however, will lead to result bundle names containing spaces. this PR fixes this.


## :gear: Release Notes
- fixed a bug when `inputs.resultBundle` contained spaces

## :books: Documentation
n/a

## :white_check_mark: Testing
n/a

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
