### PR TITLE
add option to disable xcbeautify

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -103,6 +103,12 @@ on:
         required: false
         type: string
         default: ''
+      use_xcbeautify:
+        description: |
+          Whether the `xcodebuild` output should be piped into `xcbeautify`
+        required: false
+        type: boolean
+        default: true
       environment:
         description: |
           GitHub deployment environment to optionally adjust access to variables and secrets with additional protection rules.
@@ -244,7 +250,7 @@ jobs:
             echo "environment: ${{ inputs.environment }}"
             xcrun simctl list
       - name: Install xcbeautify
-        if: ${{ !env.selfhosted && inputs.scheme != '' }}
+        if: ${{ !env.selfhosted && inputs.scheme != '' && inputs.use_xcbeautify }}
         run: brew install xcbeautify
       - name: Cache .derivedData folder (Deprecated)
         if: ${{ inputs.cacheDerivedData }}
@@ -348,7 +354,7 @@ jobs:
               -scheme ${{ inputs.scheme }} \
               -resolvePackageDependencies \
               -derivedDataPath ".derivedData" \
-            | xcbeautify \
+            | ${{ inputs.use_xcbeautify && 'xcbeautify' || 'cat' }} \
             || true
       - name: Build and test (xcodebuild)
         if: ${{ inputs.scheme != '' }}
@@ -398,7 +404,7 @@ jobs:
               OTHER_SWIFT_FLAGS="\$(inherited) $ENABLE_TESTING_FLAG $SWIFT_VERSION_FLAG" \
               -skipPackagePluginValidation \
               -skipMacroValidation \
-            | xcbeautify
+            | ${{ inputs.use_xcbeautify && 'xcbeautify' || 'cat' }}
       - name: Fastlane
         if: ${{ inputs.fastlanelane != '' }}
         run: |


### PR DESCRIPTION
# add option to disable xcbeautify

## :recycle: Current situation & Problem
currently, we unconditionally pipe all xcodebuild output into xcbeautify. this is fine in most cases, but does lead to issues when dealing with multi-line errors being printed as part of a failing test.

for example, [this test run](https://github.com/StanfordBDHG/MyHeartCounts-StudyDefinitions/actions/runs/18354159066/job/52281736943?pr=1#step:20:2539) ended up logging only the first line of the errors, while the [full output] was in fact significantly longer.

this new option allows disabling xcbeautify, as a result keeping the full xcodebuild output (all of the verbose unnecessary information, but also full multi-line error messages).


## :gear: Release Notes
- added `use_xcbeautify` as an explicit option (enabled by default)

## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
