### PR TITLE
imprive the linkspector setup

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -46,7 +46,5 @@ jobs:
         uses: umbrelladocs/action-linkspector@v1
         with:
           filter_mode: nofilter
-          # tool_name: Static Analysis / Markdown Link Check
-          # reporter: ${{ github.event_name == 'pull_request' && 'github-pr-check' || 'github-annotations' }}
           reporter: github-pr-annotations
           fail_level: error


### PR DESCRIPTION
# imprive the linkspector setup

## :recycle: Current situation & Problem
- issue:
    - the markdown link checking job currently somehow undergoes some kind of mitosis where it ends up reporting its result (via reviewdog?) as a separate job.
    - this is problematic since this separate job isn't explicitly associated with any particular check suite (and in fact it seems impossible to actually do this; see also https://github.com/reviewdog/reviewdog/issues/403).
        - instead, the linkspector results typically get grouped into the Build and Test check suite, even though they are triggered by the Static Analysis workflow
    - the job that runs linkspector always succeeds, regardless of whether the checks themselves actually succeeded.
- solution:
    - we use a slightly different setup, where linkspector now no longer uses the `github-check` reviewdog reporter
    - instead, it uses `github-pr-annotations`
        - ideally we'd use `github-annotations` instead, but that'd require https://github.com/UmbrellaDocs/action-linkspector/pull/48 to get merged
    - additionally, we now use the `fail_level` option to have the Markdown Link Check step itself fail if linkspector finds any issues
    - as a result: we now have a single job (Markdown Link Check), that will simply directly report the results (instead of going through the separate check), and will use its status (success, failure) to indicate whether any errors were found
        - (at least i hope that's how it will work)


## :gear: Release Notes
- fixed linkspector to no longer report its results via a separate check
    - (this should also make it easier to re-run linkspector without accidentally also triggering a re-run of the entire build-and-test workflow)


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
