### PR TITLE
Add Swift Linux Build, Test, and Code Coverage Support

### DIFF
--- a/.github/workflows/create-and-upload-coverage-report.yml
+++ b/.github/workflows/create-and-upload-coverage-report.yml
@@ -21,6 +21,7 @@ on:
         description: |
           A string containing all names of the .lcov files that are downloaded from the artifacts of previous jobs.
           Multiple values are separated by a space character.
+          For proper coverage merging with .xcresult files, lcov files must contain only function coverage data.
         required: false
         type: string
     secrets:

--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: MIT
 #
 
-name: Build and Test Swift Package on Linux
+name: Swift Test
 
 on:
   workflow_call:
@@ -66,8 +66,8 @@ on:
           The Personal access token (PAT) to use with the checkout action.
         required: false
 jobs:
-  swift_build_and_test:
-    name: Build and Test Swift on Linux
+  swift_test:
+    name: Swift Test
     runs-on: ${{ fromJson(inputs.runs_on_labels) }}
     defaults:
       run:


### PR DESCRIPTION
# *Add Swift Linux Build, Test, and Code Coverage Support*

## :recycle: Current situation & Problem
- Current CI only covers macOS/iOS targets, leaving Linux builds untested and without coverage.
- https://github.com/StanfordSpezi/SpeziFoundation/pull/47


## :gear: Release Notes
- Added Linux build and test steps
- Integrated lcov coverage merging across platforms

## :books: Documentation
--


## :white_check_mark: Testing
--


### Code of Conduct & Contributing Guidelines
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
