### PR TITLE
add `spm-disable-prebuilts` option

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -83,11 +83,11 @@ on:
         required: false
         type: string
         default: ''
-      xcodebuild-extra-flags:
+      spm-disable-prebuilts:
         description: |
-          Additional flags that should be passed to xcodebuild
-        type: string
-        default: ''
+          Disables package prebuilts when resolving SPM dependencies
+        type: boolean
+        default: false
       fastlanelane:
         description: |
           The lane of the fastlane command.
@@ -353,6 +353,7 @@ jobs:
               -scheme ${{ inputs.scheme }} \
               -resolvePackageDependencies \
               -derivedDataPath ".derivedData" \
+              ${{ inputs.spm-disable-prebuilts && '-IDEPackageEnablePrebuilts=NO' || '' }} \
             | xcbeautify \
             || true
       - name: Build and test (xcodebuild)
@@ -403,7 +404,7 @@ jobs:
               OTHER_SWIFT_FLAGS="\$(inherited) $ENABLE_TESTING_FLAG $SWIFT_VERSION_FLAG" \
               -skipPackagePluginValidation \
               -skipMacroValidation \
-              ${{ inputs.xcodebuild-extra-flags }} \
+              ${{ inputs.spm-disable-prebuilts && '-IDEPackageEnablePrebuilts=NO' || '' }} \
             | xcbeautify
       - name: Fastlane
         if: ${{ inputs.fastlanelane != '' }}


### PR DESCRIPTION
# add `spm-disable-prebuilts` option

## :recycle: Current situation & Problem
for some reason, the SPM prebuilts for swift-syntax currently don't work when compiling a package for testing using Xcode 26.1, if the destination is any non-macOS platform.

this PR adds a new `spm-disable-prebuilts` input to the xcodebuild-or-fastlane workflow, to allow a package to optionally disable the use of prebuilts. this allows the package to continue building without issues, albeit slightly slower than if the prebuilts were functional.

the `spm-disable-prebuilts` defaults to `false`.

the immediate use case for this is SpeziScheduler, which currently fails to compile because of its use of swift-syntax.
hopefully we will only need to add `spm-disable-prebuilts: true` to that repo's workflows for a short while.

## :gear: Release Notes
- added a `spm-disable-prebuilts` option to the xcodebuild-or-fastlane workflow


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
