### PR TITLE
Fix markdown link check

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -10,13 +10,18 @@ name: Check Links
 
 on:
   workflow_call:
+    inputs:
+      runs_on_labels:
+        description: |
+          JSON-based collection of labels indicating which type of github runner should be chosen.
+        required: false
+        type: string
+        default: '["macOS", "self-hosted"]'
 
 jobs:
   markdown_link_check:
     name: Check Links
-    runs-on:
-      - macOS
-      - self-hosted
+    runs-on: ${{ fromJson(inputs.runs_on_labels) }}
     steps:
       - uses: actions/checkout@v4
       - name: Check and Create Linkspector Configuration


### PR DESCRIPTION
# *Fix markdown link check*

## :recycle: Current situation & Problem
- Markdown link check fails due to rate limiting from GitHub runner IP ranges


## :gear: Release Notes
- Fix markdown link check


## :books: Documentation
-/-


## :white_check_mark: Testing
-/-


### Code of Conduct & Contributing Guidelines
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
