### PR TITLE
Group test matrix jobs by platform instead of configuration

### DIFF
--- a/.github/workflows/swift-package-test.yml
+++ b/.github/workflows/swift-package-test.yml
@@ -39,8 +39,8 @@ jobs:
     uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     strategy:
       matrix:
-        config: [Debug, Release]
         platform: ${{ fromJSON(inputs.platform_matrix) }}
+        config: [Debug, Release]
       fail-fast: false
     with:
       job_name: ${{ format('{0} ({1})', matrix.platform.name, matrix.config) }}
@@ -57,8 +57,8 @@ jobs:
     uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     strategy:
       matrix:
-        config: [Debug, Release]
         platform: ${{ fromJSON(inputs.ui_platform_matrix) }}
+        config: [Debug, Release]
       fail-fast: false
     with:
       job_name: ${{ format('UI {0} ({1})', matrix.platform.name, matrix.config) }}


### PR DESCRIPTION
  # Group test matrix jobs by platform instead of configuration

  ## :recycle: Current situation & Problem
  In the **swift-package-test** workflow, the matrix jobs expand grouped by build configuration first, producing an order like "P1 Debug, P2 Debug, P3 Debug,
  P1 Release, P2 Release, P3 Release". This makes it harder to scan results per platform in the Actions UI, since Debug and Release runs for the same platform
  are separated.

  ## :gear: Release Notes
  - Reordered the matrix dimensions in **package_tests** and **ui_tests** so **platform** becomes the outer loop and **config** the inner loop.
  - Jobs now expand as "P1 Debug, P1 Release, P2 Debug, P2 Release, ..." which groups Debug and Release runs per platform.
  - No functional change to the tests being executed; only the job expansion order changes.

  ## :books: Documentation
  -/-

  ## :white_check_mark: Testing
  -/-

  ## :pencil: Code of Conduct & Contributing Guidelines
  - [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing
  Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).