### PR TITLE
Add opt-in Metal Toolchain download for xcodebuild

### DIFF
--- a/.github/workflows/swift-package-ci.yml
+++ b/.github/workflows/swift-package-ci.yml
@@ -17,6 +17,9 @@ on:
       linux_runners:
         type: string
         default: '["blacksmith-4vcpu-ubuntu-2404"]'
+      downloadMetalToolchain:
+        type: boolean
+        default: false
     secrets:
       CODECOV_TOKEN:
         required: false
@@ -41,6 +44,7 @@ jobs:
       ui_platform_matrix: ${{ needs.setup.outputs.ui_platform_matrix }}
       linux_run_tests: ${{ inputs.linux_run_tests }}
       linux_runners: ${{ inputs.linux_runners }}
+      downloadMetalToolchain: ${{ inputs.downloadMetalToolchain }}
     secrets: inherit
 
   static_analysis:

--- a/.github/workflows/swift-package-test.yml
+++ b/.github/workflows/swift-package-test.yml
@@ -29,6 +29,9 @@ on:
       linux_runners:
         type: string
         default: '["blacksmith-4vcpu-ubuntu-2404"]'
+      downloadMetalToolchain:
+        type: boolean
+        default: false
     secrets:
       CODECOV_TOKEN:
         required: false
@@ -48,6 +51,7 @@ jobs:
       scheme: ${{ inputs.scheme }}
       destination: ${{ matrix.platform.destination }}
       buildConfig: ${{ matrix.config }}
+      downloadMetalToolchain: ${{ inputs.downloadMetalToolchain }}
       resultBundle: ${{ format('{0}-{1}-{2}.xcresult', inputs.package_name, matrix.platform.name, matrix.config) }}
       artifactname: ${{ format('{0}-{1}-{2}.xcresult', inputs.package_name, matrix.platform.name, matrix.config) }}
 
@@ -67,6 +71,7 @@ jobs:
       scheme: ${{ matrix.platform.scheme }}
       destination: ${{ matrix.platform.destination }}
       buildConfig: ${{ matrix.config }}
+      downloadMetalToolchain: ${{ inputs.downloadMetalToolchain }}
       resultBundle: ${{ format('{0}-{1}-{2}.xcresult', matrix.platform.scheme, matrix.platform.name, matrix.config) }}
       artifactname: ${{ format('{0}-{1}-{2}.xcresult', matrix.platform.scheme, matrix.platform.name, matrix.config) }}
 

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -95,6 +95,15 @@ on:
           Disables package prebuilts when resolving SPM dependencies
         type: boolean
         default: false
+      downloadMetalToolchain:
+        description: |
+          Download the Metal Toolchain before building.
+          Required for packages that compile Metal shaders (e.g., via mlx-swift), as recent Xcode
+          versions no longer bundle the Metal Toolchain and fail with "missing Metal Toolchain".
+          Defaults to false so builds that do not use Metal are unaffected.
+        required: false
+        type: boolean
+        default: false
       fastlanelane:
         description: |
           The lane of the fastlane command.
@@ -255,6 +264,9 @@ jobs:
             echo "github-hosted: ${{ runner.environment == 'github-hosted' }}"
             echo "environment: ${{ inputs.environment }}"
             xcrun simctl list
+      - name: Download Metal Toolchain
+        if: ${{ inputs.downloadMetalToolchain }}
+        run: xcodebuild -downloadComponent MetalToolchain
       - name: Install xcbeautify
         if: ${{ runner.environment == 'github-hosted' && inputs.scheme != '' }}
         run: brew install xcbeautify


### PR DESCRIPTION
## Problem

Recent Xcode versions no longer bundle the Metal Toolchain. Packages that compile Metal shaders (e.g. via `mlx-swift`) now fail to build in CI with:

```
error: cannot execute tool 'metal' due to missing Metal Toolchain; use: xcodebuild -downloadComponent MetalToolchain
```

This surfaced in [StanfordSpezi/SpeziLLM](https://github.com/StanfordSpezi/SpeziLLM) (which pulls in `mlx-swift` via `SpeziLLMLocal`): every Build & Test job fails before any test runs.

## Change

Add an opt-in `downloadMetalToolchain` input (**default `false`**) that runs `xcodebuild -downloadComponent MetalToolchain` before building, threaded through:

`swift-package-ci.yml` → `swift-package-test.yml` → `xcodebuild-or-fastlane.yml`

Because it defaults to `false`, repositories that do not use Metal are completely unaffected — only consumers that opt in pay the download cost.

## Usage

```yaml
jobs:
  ci:
    uses: StanfordBDHG/.github/.github/workflows/swift-package-ci.yml@v2
    with:
      downloadMetalToolchain: true
```

## Validation
- `actionlint` passes on all three modified workflows (no workflow-syntax errors).