### PR TITLE
Remove the API breaking-changes check from static analysis

### DIFF
--- a/.github/workflows/swift-package-static-analysis.yml
+++ b/.github/workflows/swift-package-static-analysis.yml
@@ -20,6 +20,9 @@ on:
       platform_version:
         type: string
         default: ""
+      # Deprecated: the API breaking-changes check has been removed from this workflow. This input is
+      # retained so existing callers that set it (e.g. `diagnose_breaking_changes: false`) do not fail,
+      # but it no longer has any effect.
       diagnose_breaking_changes:
         type: boolean
         default: true
@@ -38,12 +41,3 @@ jobs:
   markdown_link_check:
     name: Markdown Link Check
     uses: StanfordBDHG/.github/.github/workflows/markdown-link-check.yml@v2
-  breaking_changes:
-    name: Diagnose Breaking Changes
-    uses: StanfordBDHG/.github/.github/workflows/swift-package-breaking-changes.yml@v2
-    if: ${{ inputs.diagnose_breaking_changes && github.ref_name != 'main' }}
-    with:
-      library_products: ${{ inputs.library_products }}
-      platform_name: ${{ inputs.platform_name }}
-      platform_version: ${{ inputs.platform_version }}
-      runsonlabels: '["macOS", "self-hosted"]'


### PR DESCRIPTION
## Problem

`swift package diagnose-api-breaking-changes` builds packages under a stricter SwiftPM invocation than the regular xcodebuild-based test job. For packages with generated code or certain dependencies, it fails to **build** at all — not because of an API break, but for build reasons the real test job handles fine. Recent examples from [StanfordSpezi/SpeziLLM](https://github.com/StanfordSpezi/SpeziLLM):

- `ambiguous implicit access level for import of 'Foundation'` in a generated OpenAPI client (mixed `package import` / plain `import`)
- dependency source (`swift-transformers`) that compiles under xcodebuild but not the diagnose build

The job reports **`… failed for a non-breakage reason`** / `HAS_BREAKING_CHANGES: false` and goes red — a false, unactionable failure on every PR for the affected repos.

## Change

Remove the `breaking_changes` job from `swift-package-static-analysis.yml` so it no longer runs for **any** consumer of `swift-package-ci.yml` / `swift-package-static-analysis.yml`.

The `diagnose_breaking_changes` input is **retained as a no-op** so existing callers that set it (e.g. SpeziScheduler passes `diagnose_breaking_changes: false`) don't fail on an unknown input. The `swift-package-breaking-changes.yml` reusable workflow file is left in place (now orphaned from the chain) to avoid breaking any direct external callers.

## Rollout

Takes effect for `@v2` consumers once this merges and `v2` is re-released (same as the Metal Toolchain change).